### PR TITLE
Bug #5197 : modifying the name of the called method for document adjustment in order to prevent call of treatments that were already existing but with wrong corrections (Fortunately, these wrong corrections were never called by dbBuilder).

### DIFF
--- a/src/main/java/org/silverpeas/migration/jcr/wysiwyg/WysiwygCorrector.java
+++ b/src/main/java/org/silverpeas/migration/jcr/wysiwyg/WysiwygCorrector.java
@@ -42,7 +42,7 @@ public class WysiwygCorrector extends DbBuilderDynamicPart {
     this.service = new SimpleDocumentService();
   }
 
-  public void migrateDocuments() throws Exception {
+  public void adjustDocuments() throws Exception {
     long totalNumberOfMigratedFiles = 0L;
     List<WysiwygDocumentMerger> mergers = buildWysiwygDocumentMergers();
     List<Future<Long>> result = executor.invokeAll(mergers);


### PR DESCRIPTION
Don't forget to check https://github.com/Silverpeas/Silverpeas-Core/pull/456
