### PR TITLE
bug #5308 : Some HTML entities in some texts are encoded again for HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.owasp.encoder</groupId>
+      <artifactId>encoder</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/silverpeas/migration/publication/HtmlUnescaper.java
+++ b/src/main/java/org/silverpeas/migration/publication/HtmlUnescaper.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2000-2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Writer Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.publication;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.silverpeas.dbbuilder.dbbuilder_dl.DbBuilderDynamicPart;
+
+import static org.apache.commons.lang3.StringEscapeUtils.unescapeHtml4;
+
+/**
+ * Migration of data in publications and in comments containing HTML entities to their original
+ * representations.
+ *
+ * @author mmoquillon
+ */
+public class HtmlUnescaper extends DbBuilderDynamicPart {
+
+  private static final String PUBLICATION_SELECTION
+      = "select pubId, pubName, pubDescription from sb_publication_publi where pubUpdateDate > '2013/10/07'";
+  private static final String PUBLICATION_UPDATE
+      = "update sb_publication_publi set pubName = ?, pubDescription = ? where pubId = ?";
+  private static final String COMMENT_SELECTION
+      = "select commentId, commentComment from sb_comment_comment where commentModificationDate > '2013/10/07'";
+  private static final String COMMENT_UPDATE
+      = "update sb_comment_comment set commentComment = ? where commentId = ?";
+
+  public void unescapeHtml() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    // use futures to block at the tasks termination to ensure no other sql executions are
+    // interleaved within the execution of these tasks.
+    List<Future<Void>> futures = executor.invokeAll(Arrays.asList(unescapePublications(),
+        unescapeComments()));
+    for (Future<Void> future : futures) {
+      future.get();
+    }
+    executor.shutdown();
+  }
+
+  private Callable<Void> unescapePublications() throws Exception {
+    return new Callable<Void>() {
+
+      @Override
+      public Void call() throws Exception {
+        getConsole().printMessage("Update of the publications after 07 october 2013");
+        PreparedStatement selector = null;
+        PreparedStatement updater = null;
+        ResultSet rs = null;
+        try {
+          selector = getConnection().prepareStatement(PUBLICATION_SELECTION);
+          updater = getConnection().prepareStatement(PUBLICATION_UPDATE);
+          rs = selector.executeQuery();
+          while (rs.next()) {
+            int id = rs.getInt("pubId");
+            String name = unescapeHtml4(rs.getString("pubName"));
+            String description = unescapeHtml4(rs.getString("pubDescription"));
+            updater.setString(1, name);
+            updater.setString(2, description);
+            updater.setInt(3, id);
+            if (updater.executeUpdate() == 0) {
+              getConsole().printWarning("Update of the publication " + id + " does nothing!");
+            }
+          }
+        } finally {
+          if (rs != null) {
+            rs.close();
+          }
+          if (selector != null) {
+            selector.close();
+          }
+          if (updater != null) {
+            updater.close();
+          }
+        }
+        return null;
+      }
+    };
+  }
+
+  private Callable<Void> unescapeComments() throws SQLException {
+    return new Callable<Void>() {
+
+      @Override
+      public Void call() throws Exception {
+        getConsole().printMessage("Update of the comments after 07 october 2013");
+        PreparedStatement selector = null;
+        PreparedStatement updater = null;
+        ResultSet rs = null;
+        try {
+          selector = getConnection().prepareStatement(COMMENT_SELECTION);
+          updater = getConnection().prepareStatement(COMMENT_UPDATE);
+          rs = selector.executeQuery();
+          while (rs.next()) {
+            int id = rs.getInt("commentId");
+            String content = unescapeHtml4(rs.getString("commentComment"));
+            updater.setString(1, content);
+            updater.setInt(2, id);
+            if (updater.executeUpdate() == 0) {
+              getConsole().printWarning("Update of the comment " + id + " does nothing!");
+            }
+          }
+        } finally {
+          if (rs != null) {
+            rs.close();
+          }
+          if (selector != null) {
+            selector.close();
+          }
+          if (updater != null) {
+            updater.close();
+          }
+        }
+        return null;
+      }
+    };
+  }
+}

--- a/src/test/java/org/silverpeas/migration/publication/HtmlUnescaperTest.java
+++ b/src/test/java/org/silverpeas/migration/publication/HtmlUnescaperTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2000-2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Writer Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.publication;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.inject.Inject;
+import javax.sql.DataSource;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.dbunit.DataSourceDatabaseTester;
+import org.dbunit.IDatabaseTester;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.ReplacementDataSet;
+import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.owasp.encoder.Encode;
+import org.silverpeas.test.SystemInitializationForTests;
+import org.silverpeas.util.Console;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests on the migration of the contents of the publications and of the comments updated from
+ * 2013/10/07.
+ *
+ * @author mmoquillon
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "/spring-publi-datasource.xml")
+public class HtmlUnescaperTest {
+
+  private IDatabaseTester databaseTester;
+  @Inject
+  private DataSource dataSource;
+
+  public HtmlUnescaperTest() {
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    SystemInitializationForTests.initialize();
+  }
+
+  @Before
+  public void prepareDatabase() throws Exception {
+    assertThat(dataSource, notNullValue());
+    databaseTester = new DataSourceDatabaseTester(dataSource);
+    databaseTester.setDataSet(getDataSet());
+    databaseTester.onSetup();
+  }
+
+  @After
+  public void cleanDatabase() throws Exception {
+    databaseTester.onTearDown();
+  }
+
+  @Test
+  public void unescapeSomeEncodedHtmlText() {
+    String htmlText = "L'origine de ce livre est à <celui-ci>";
+    String encodedText = Encode.forHtml(htmlText);
+    String decodedText = StringEscapeUtils.unescapeHtml4(encodedText);
+    assertThat(decodedText, is(htmlText));
+  }
+
+  @Test
+  public void unescapePublicationAndCommentsText() throws Exception {
+    HtmlUnescaper unescaper = new HtmlUnescaper();
+    unescaper.setConnection(dataSource.getConnection());
+    unescaper.setConsole(new Console());
+
+    unescaper.unescapeHtml();
+
+    String text = (String) databaseTester.getDataSet().getTable("sb_publication_publi").getValue(1,
+        "pubname");
+    assertThat(text, not(containsString("&#39;")));
+
+    text = (String) databaseTester.getDataSet().getTable("sb_publication_publi").getValue(1,
+        "pubdescription");
+    assertThat(text, not(containsString("&#39;")));
+
+    text = (String) databaseTester.getDataSet().getTable("sb_comment_comment").getValue(1,
+        "commentcomment");
+    assertThat(text, not(containsString("&#39;")));
+
+    text = (String) databaseTester.getDataSet().getTable("sb_comment_comment").getValue(3,
+        "commentcomment");
+    assertThat(text, not(containsString("&#39;")));
+    assertThat(text, not(containsString("&gt;")));
+    assertThat(text, not(containsString("&#lt;")));
+  }
+
+  protected IDataSet getDataSet() throws Exception {
+    InputStream in = getClass().getResourceAsStream("publication-dataset.xml");
+    try {
+      ReplacementDataSet dataSet = new ReplacementDataSet(new FlatXmlDataSetBuilder().build(in));
+      dataSet.addReplacementObject("[NULL]", null);
+      return dataSet;
+    } finally {
+      IOUtils.closeQuietly(in);
+    }
+  }
+}

--- a/src/test/resources/org/silverpeas/migration/publication/create-database.sql
+++ b/src/test/resources/org/silverpeas/migration/publication/create-database.sql
@@ -1,0 +1,41 @@
+CREATE TABLE SB_Publication_Publi
+(
+	pubId			int		NOT NULL ,
+	infoId			varchar (50) 	NULL ,
+	pubName			varchar (400)	NOT NULL ,
+	pubDescription		varchar (2000)	NULL ,
+	pubCreationDate		varchar (10)	NOT NULL ,
+	pubBeginDate		varchar (10)	NOT NULL ,
+	pubEndDate		varchar (10)	NOT NULL ,
+	pubCreatorId		varchar (100)	NOT NULL ,
+	pubImportance		int		NULL ,
+	pubVersion		varchar (100)	NULL ,
+	pubKeywords		varchar (1000)	NULL ,
+	pubContent		varchar (2000)	NULL ,
+	pubStatus		varchar (100)	NULL ,
+	pubUpdateDate		varchar (10)	NULL ,
+	instanceId		varchar (50)	NOT NULL ,
+	pubUpdaterId            varchar (100)	NULL ,
+	pubValidateDate		varchar (10)	NULL ,
+	pubValidatorId		varchar (50)	NULL ,
+	pubBeginHour		varchar (5)	NULL ,
+	pubEndHour		varchar (5)	NULL ,
+	pubAuthor		varchar (50)	NULL,
+	pubTargetValidatorId	varchar (50)	NULL,
+	pubCloneId		int		DEFAULT (-1),
+	pubCloneStatus		varchar (50)	NULL,
+	lang			char(2)		NULL,
+	pubdraftoutdate		varchar (10)	NULL
+);
+
+CREATE TABLE SB_Comment_Comment
+	(
+	commentId int not null,
+	commentOwnerId int not null,
+	commentCreationDate char (10) not null,
+	commentModificationDate char (10),
+	commentComment varchar (2000) not null,
+	instanceId varchar (50) not null,
+	resourceType varchar (50) not null,
+	resourceId varchar (50) not null
+	);

--- a/src/test/resources/org/silverpeas/migration/publication/publication-dataset.xml
+++ b/src/test/resources/org/silverpeas/migration/publication/publication-dataset.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+
+  <sb_comment_comment commentId="2" commentOwnerId="2773" commentCreationDate="2013/09/10" commentModificationDate="2013/09/10"
+                      commentComment="smalltalk back to the future" instanceId="kmelia1" resourceType="Publication" resourceId="1"/>
+  <sb_comment_comment commentId="12" commentOwnerId="0" commentCreationDate="2013/11/22" commentModificationDate="2013/11/22"
+                      commentComment="j&#39;ai déplacé ta publication dans une autre GED" instanceId="kmelia7" resourceType="Publication" resourceId="205"/>
+  <sb_comment_comment commentId="22" commentOwnerId="2773" commentCreationDate="2013/11/22" commentModificationDate="2013/11/22"
+                      commentComment="boo le commentaire" instanceId="kmelia1" resourceType="Publication" resourceId="206"/>
+  <sb_comment_comment commentId="36" commentOwnerId="2773" commentCreationDate="2014/02/21" commentModificationDate="2014/02/21"
+                      commentComment="L&#39;apostrophe &gt; sans fin &lt;" instanceId="kmelia1" resourceType="Publication" resourceId="256"/>
+
+  <sb_publication_publi pubid="101"  infoid="0"  pubname="Publication 2" pubdescription="Publication 2 Valide avec dates ok"  pubcreationdate="2008/11/18"
+                        pubbegindate="2009/10/18" pubenddate="2020/12/18"  pubcreatorid="101" pubimportance="5"
+                        pubversion=""  pubkeywords="test"  pubcontent="Contenu de la publication 2"
+                        pubstatus="Valid" pubupdatedate="2010/10/26"
+                        instanceid="kmelia1" pubupdaterid="200" pubvalidatedate="2008/11/18"
+                        pubvalidatorid="300" pubbeginhour="01:10" pubendhour="20:35" pubauthor="Bart Simpson"
+                        pubtargetvalidatorid="[NULL]" pubcloneid="-1" pubclonestatus="[NULL]" lang="fr" />
+  <sb_publication_publi pubid="205"  infoid="0"  pubname="Utilisation d&#39;AngularJS dans Silverpeas" pubdescription="Présentation de l&#39;utilisation d&#39;AngularJS dans une page Web de Silverpeas"  pubcreationdate="2013/11/18"
+                        pubbegindate="2013/11/18" pubenddate="9999/99/99"  pubcreatorid="103" pubimportance="5"
+                        pubversion=""  pubkeywords="Silverpeas, AngularJS, Web, Javascript"  pubcontent="''"
+                        pubstatus="Valid" pubupdatedate="2013/11/22"
+                        instanceid="kmelia1" pubupdaterid="103" pubvalidatedate="2013/11/22"
+                        pubvalidatorid="0" pubbeginhour="00:00" pubendhour="23:59" pubauthor="[NULL]"
+                        pubtargetvalidatorid="[NULL]" pubcloneid="-1" pubclonestatus="[NULL]" lang="[NULL]" />
+  <sb_publication_publi pubid="255"  infoid="0"  pubname="Vente anticipé sur un marché en expansion" pubdescription="Technique de vente avancé"  pubcreationdate="2013/11/18"
+                        pubbegindate="2013/11/18" pubenddate="9999/99/99"  pubcreatorid="103" pubimportance="5"
+                        pubversion=""  pubkeywords="[NULL]"  pubcontent="''"
+                        pubstatus="Valid" pubupdatedate="2013/11/22"
+                        instanceid="kmelia7" pubupdaterid="103" pubvalidatedate="2013/11/22"
+                        pubvalidatorid="0" pubbeginhour="00:00" pubendhour="23:59" pubauthor="[NULL]"
+                        pubtargetvalidatorid="[NULL]" pubcloneid="-1" pubclonestatus="[NULL]" lang="[NULL]" />
+
+</dataset>

--- a/src/test/resources/spring-publi-datasource.xml
+++ b/src/test/resources/spring-publi-datasource.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+
+  <jdbc:embedded-database id="dataSource" type="H2" >
+    <jdbc:script location="classpath:/org/silverpeas/migration/publication/create-database.sql" />
+  </jdbc:embedded-database>
+
+</beans>


### PR DESCRIPTION
 Unescape all HTML entities in the publications and in the comments updated since 2013-10-07 (the release of 5.12.4).

Don't forget to integrate also the branch bug-5308 in Silverpeas-Core and in Silverpeas-Components.

The integration should be done also for 5.12.8-SNAPSHOT.
