### PR TITLE
Bug #5329 - adding a treatment to purge empty WYSIWYG contents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
     </dependency>

--- a/src/main/java/org/silverpeas/migration/jcr/service/RepositoryManager.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/RepositoryManager.java
@@ -23,17 +23,6 @@
  */
 package org.silverpeas.migration.jcr.service;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.HashMap;
-import java.util.Map;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
-import javax.jcr.UnsupportedRepositoryOperationException;
-import javax.jcr.nodetype.InvalidNodeTypeDefinitionException;
-import javax.jcr.nodetype.NodeTypeExistsException;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.api.JackrabbitRepository;
@@ -41,9 +30,23 @@ import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.jackrabbit.commons.cnd.CndImporter;
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.jackrabbit.core.RepositoryFactoryImpl;
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.apache.jackrabbit.core.config.RepositoryConfig;
 import org.silverpeas.util.ConfigurationHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.nodetype.InvalidNodeTypeDefinitionException;
+import javax.jcr.nodetype.NodeTypeExistsException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author ehugonnet
@@ -52,6 +55,11 @@ public class RepositoryManager {
 
   private static final Logger logger = LoggerFactory.getLogger(RepositoryManager.class);
   private JackrabbitRepository repository;
+  private static boolean isJcrTestEnv = false;
+
+  public static void setIsJcrTestEnv() {
+    isJcrTestEnv = true;
+  }
 
   public RepositoryManager() {
     try {
@@ -79,7 +87,11 @@ public class RepositoryManager {
     Map<String, String> parameters = new HashMap<String, String>(2);
     parameters.put(RepositoryFactoryImpl.REPOSITORY_HOME, repositoryHome);
     parameters.put(RepositoryFactoryImpl.REPOSITORY_CONF, conf);
-    repository = (JackrabbitRepository) JcrUtils.getRepository(parameters);
+    if (!isJcrTestEnv) {
+      repository = (JackrabbitRepository) JcrUtils.getRepository(parameters);
+    } else {
+      repository = RepositoryImpl.create(RepositoryConfig.create(conf, repositoryHome));
+    }
     Reader reader = new InputStreamReader(
         this.getClass().getClassLoader().getResourceAsStream("silverpeas-jcr.txt"), Charsets.UTF_8);
     try {
@@ -114,5 +126,9 @@ public class RepositoryManager {
 
   public void shutdown() {
     this.repository.shutdown();
+  }
+
+  public static boolean isIsJcrTestEnv() {
+    return isJcrTestEnv;
   }
 }

--- a/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleAttachment.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleAttachment.java
@@ -23,15 +23,16 @@
  */
 package org.silverpeas.migration.jcr.service.model;
 
+import org.silverpeas.migration.jcr.service.ConverterUtil;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Date;
-import org.silverpeas.migration.jcr.service.ConverterUtil;
 
 /**
  * @author ehugonnet
  */
-public class SimpleAttachment implements Serializable {
+public class SimpleAttachment implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -6153003608158238503L;
   private String filename;
@@ -58,6 +59,24 @@ public class SimpleAttachment implements Serializable {
     this.createdBy = createdBy;
     setCreated(created);
     this.xmlFormId = xmlFormId;
+  }
+
+  public SimpleAttachment(final String filename, final String language, final String title,
+      final String description, final long size, final String contentType, final String createdBy,
+      final Date created, final String updatedBy, final Date updated, final String xmlFormId,
+      final File file) {
+    this.filename = filename;
+    this.language = language;
+    this.title = title;
+    this.description = description;
+    this.size = size;
+    this.contentType = contentType;
+    this.createdBy = createdBy;
+    this.created = created;
+    this.updatedBy = updatedBy;
+    this.updated = updated;
+    this.xmlFormId = xmlFormId;
+    this.file = file;
   }
 
   public SimpleAttachment() {
@@ -252,5 +271,15 @@ public class SimpleAttachment implements Serializable {
         + title + ", description=" + description + ", size=" + size + ", contentType=" + contentType
         + ", createdBy=" + createdBy + ", created=" + created + ", updatedBy=" + updatedBy
         + ", updated=" + updated + ", xmlFormId=" + xmlFormId + '}';
+  }
+
+  @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+  @Override
+  public SimpleAttachment clone() {
+    try {
+      return (SimpleAttachment) super.clone();
+    } catch (CloneNotSupportedException e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleDocument.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleDocument.java
@@ -36,7 +36,7 @@ import static java.io.File.separatorChar;
  *
  * @author ehugonnet
  */
-public class SimpleDocument implements Serializable {
+public class SimpleDocument implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 8778738762037114180L;
   public static final String WEBDAV_FOLDER = "webdav";
@@ -144,6 +144,32 @@ public class SimpleDocument implements Serializable {
     this.alert = DateUtil.getBeginOfDay(alert);
     this.expiry = DateUtil.getBeginOfDay(expiry);
     this.comment = comment;
+    this.file = file;
+  }
+
+  public SimpleDocument(final SimpleDocumentPK pk, final String foreignId, final int order,
+      final boolean versioned, final String editedBy, final Date reservation, final Date alert,
+      final Date expiry, final String status, final String cloneId, final int minorVersion,
+      final int majorVersion, final boolean publicDocument, final String nodeName,
+      final String comment, final DocumentType documentType, final String oldContext,
+      final SimpleAttachment file) {
+    this.pk = pk;
+    this.foreignId = foreignId;
+    this.order = order;
+    this.versioned = versioned;
+    this.editedBy = editedBy;
+    this.reservation = reservation;
+    this.alert = alert;
+    this.expiry = expiry;
+    this.status = status;
+    this.cloneId = cloneId;
+    this.minorVersion = minorVersion;
+    this.majorVersion = majorVersion;
+    this.publicDocument = publicDocument;
+    this.nodeName = nodeName;
+    this.comment = comment;
+    this.documentType = documentType;
+    this.oldContext = oldContext;
     this.file = file;
   }
 
@@ -512,5 +538,18 @@ public class SimpleDocument implements Serializable {
 
   public String getFolder() {
     return documentType.getFolderName();
+  }
+
+  @SuppressWarnings("CloneDoesntDeclareCloneNotSupportedException")
+  @Override
+  public SimpleDocument clone() {
+    try {
+      SimpleDocument clone = (SimpleDocument) super.clone();
+      clone.setPK(clone.getPk().clone());
+      clone.setAttachment(clone.getAttachment().clone());
+      return clone;
+    } catch (CloneNotSupportedException e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleDocumentPK.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/model/SimpleDocumentPK.java
@@ -98,4 +98,9 @@ public class SimpleDocumentPK extends WAPrimaryKey {
         append(getComponentName()).append(", oldSilverpeasId=").append(oldSilverpeasId).append('}');
     return buffer.toString();
   }
+
+  @Override
+  public SimpleDocumentPK clone() {
+    return (SimpleDocumentPK) super.clone();
+  }
 }

--- a/src/main/java/org/silverpeas/migration/jcr/service/model/WAPrimaryKey.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/model/WAPrimaryKey.java
@@ -36,7 +36,7 @@ import java.io.Serializable;
  * @author Nicolas Eysseric
  * @version 1.0
  */
-public abstract class WAPrimaryKey implements Serializable {
+public abstract class WAPrimaryKey implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -2456912022917180222L;
 
@@ -227,5 +227,14 @@ public abstract class WAPrimaryKey implements Serializable {
 
   public String getInstanceId() {
     return getComponentName();
+  }
+
+  @Override
+  public WAPrimaryKey clone() {
+    try {
+      return (WAPrimaryKey) super.clone();
+    } catch (CloneNotSupportedException e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/org/silverpeas/migration/jcr/service/repository/DocumentConverter.java
+++ b/src/main/java/org/silverpeas/migration/jcr/service/repository/DocumentConverter.java
@@ -182,8 +182,13 @@ public class DocumentConverter extends AbstractJcrConverter {
   }
 
   public void fillNode(SimpleDocument document, Node documentNode) throws RepositoryException {
+    fillNode(document, documentNode, false);
+  }
+
+  public void fillNode(SimpleDocument document, Node documentNode, boolean skipAttachmentContent)
+      throws RepositoryException {
     setDocumentNodeProperties(document, documentNode);
-    if (document.getAttachment() != null) {
+    if (!skipAttachmentContent && document.getAttachment() != null) {
       Node attachmentNode = getAttachmentNode(document.getAttachment().getNodeName(), documentNode);
       attachmentConverter.fillNode(document.getAttachment(), attachmentNode);
     }

--- a/src/main/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygDocumentPurger.java
+++ b/src/main/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygDocumentPurger.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.wysiwyg.purge;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.silverpeas.migration.jcr.service.ConverterUtil;
+import org.silverpeas.migration.jcr.service.SimpleDocumentService;
+import org.silverpeas.migration.jcr.service.model.SimpleDocument;
+import org.silverpeas.util.Console;
+import org.silverpeas.util.MapUtil;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+/**
+ * Purge treatment.
+ */
+class WysiwygDocumentPurger implements Callable<WysiwygDocumentPurger.Result> {
+
+  private final String componentId;
+  private final SimpleDocumentService service;
+  private final Console console;
+
+  /**
+   * Default constructor.
+   * @param instanceId the identifier of the current performed component.
+   * @param service the attachement services.
+   * @param console the console to report logs.
+   */
+  WysiwygDocumentPurger(String instanceId, SimpleDocumentService service, Console console) {
+    this.componentId = instanceId;
+    this.service = service;
+    this.console = console;
+  }
+
+  @Override
+  public Result call() throws Exception {
+    console
+        .printMessage("Starting wysiwyg contents purge for component instance id " + componentId);
+    Result result = purgeWysiwyg();
+    String message = "Finishing wysiwyg contents purge for component instance id " + componentId;
+    if (result.getNbWysiwygContentPurged() > 0L) {
+      message += " with " + result.getNbWysiwygContentPurged() + " wysiwyg content(s) purged";
+    } else {
+      message += " with no wysiwyg content purged";
+    }
+    if (result.getNbWysiwygFilenameRenamed() > 0L) {
+      message +=
+          " and " + result.getNbWysiwygFilenameRenamed() + " wysiwyg content file name(s) renamed";
+    } else {
+      message += " and no wysiwyg content file name renamed";
+    }
+    console.printMessage(message);
+    return result;
+  }
+
+  private Result purgeWysiwyg() {
+    Result result = new Result();
+    List<String> foreignIdsWithWysiwyg = service.listForeignIdsWithWysiwyg(componentId);
+    for (String foreignIdWithWysiwyg : foreignIdsWithWysiwyg) {
+      String commonLogPart = "instanceId=" + componentId + ", foreignId=" +
+          foreignIdWithWysiwyg;
+      console.printMessage(commonLogPart + " - verifying wysiwyg contents ...");
+
+      // Getting documents ordered by their names
+      ForeignIdProcessContext context = new ForeignIdProcessContext(
+          service.listWysiwygByForeignId(componentId, foreignIdWithWysiwyg));
+
+      int nbContents = context.getWysiwygOfForeignId().size();
+
+      if (nbContents > 0) {
+
+        // Removing firstly the empty ones.
+        removeEmptyOnes(commonLogPart, context);
+
+        // For each language, removing duplicates
+        removeDuplicatesForEachLanguage(commonLogPart, context);
+
+        // Removing duplicates between all languages
+        removeDuplicatesBetweenAllLanguages(commonLogPart, context);
+
+        // Renaming wysiwyg content file names according to the language
+        renameFilenames(commonLogPart, context);
+      }
+
+      result.addNbWysiwygContentPurged(context.getNbRemovedContent());
+      result.addNbWysiwygFilenameRenamed(context.getNbRenamedContent());
+
+      console.printMessage(
+          commonLogPart + " - " + context.getNbRemovedContent() + "/" + nbContents + " purged.");
+      console.printMessage(
+          commonLogPart + " - " + context.getNbRenamedContent() + "/" + nbContents + " renamed.");
+    }
+    return result;
+  }
+
+  /**
+   * Removes all empty wysiwyg.
+   * @param context the context.
+   */
+  private void removeEmptyOnes(String commonLogPart, ForeignIdProcessContext context) {
+    commonLogPart += " - empty content";
+    for (WysiwygContent wysiwygContent : new ArrayList<WysiwygContent>(
+        context.getWysiwygOfForeignId())) {
+      if (isEmptyContent(wysiwygContent.getAttachment())) {
+        service.removeContent(wysiwygContent.getAttachment(), wysiwygContent.getLanguage());
+        console.printMessage(commonLogPart + " - doc=" + wysiwygContent.getNodeName() + ", lang=" +
+                wysiwygContent.getLanguage() + " - removed"
+        );
+        context.remove(wysiwygContent);
+      }
+    }
+    context.resetIndexation();
+  }
+
+  /**
+   * Removes all wysiwyg duplication for each language.
+   * @param context the context.
+   */
+  private void removeDuplicatesForEachLanguage(String commonLogPart,
+      ForeignIdProcessContext context) {
+    commonLogPart += " - duplicates for a language";
+    for (String language : new ArrayList<String>(context.getWysiwygIndexedByLangs().keySet())) {
+      List<WysiwygContent> wysiwygContentsForCurrentLanguage =
+          context.getWysiwygIndexedByLangs().get(language);
+      if (wysiwygContentsForCurrentLanguage.size() > 1) {
+        List<WysiwygContent> wysiwygContentsToRemove =
+            new ArrayList<WysiwygContent>(wysiwygContentsForCurrentLanguage);
+        WysiwygContent firstWysiwygContent = wysiwygContentsToRemove.remove(0);
+        String firstContent = firstWysiwygContent.getContent(commonLogPart);
+        for (WysiwygContent wysiwygContent : wysiwygContentsForCurrentLanguage) {
+          if (!wysiwygContent.getContent(commonLogPart).equals(firstContent)) {
+            wysiwygContentsToRemove.clear();
+            break;
+          }
+        }
+        removeWysiwygContents(commonLogPart, context, firstWysiwygContent, wysiwygContentsToRemove);
+      }
+    }
+  }
+
+  /**
+   * Removes all wysiwyg duplication between all languages.
+   * Method
+   * {@link #removeDuplicatesForEachLanguage(String, WysiwygDocumentPurger.ForeignIdProcessContext)}
+   * must be called before.
+   * @param context the context.
+   */
+  private void removeDuplicatesBetweenAllLanguages(String commonLogPart,
+      ForeignIdProcessContext context) {
+    commonLogPart += " - duplicates between all languages";
+    if (context.getWysiwygIndexedByLangs().size() > 1) {
+      WysiwygContent defaultWysiwygContent = null;
+      String firstContent = null;
+      List<WysiwygContent> wysiwygContentsToRemove =
+          new ArrayList<WysiwygContent>(context.getWysiwygIndexedByLangs().size());
+      for (Map.Entry<String, List<WysiwygContent>> languageWysiwygContents : context
+          .getWysiwygIndexedByLangs().entrySet()) {
+        if (!languageWysiwygContents.getValue().isEmpty()) {
+          // It must exist at most one SimpleDocument per language, otherwise treatments stops here.
+          if (languageWysiwygContents.getValue().size() > 1) {
+            console.printWarning(commonLogPart +
+                " - contains several JCR master nodes with different language contents, ...");
+            return;
+          }
+          WysiwygContent currentWysiwygContent = languageWysiwygContents.getValue().get(0);
+          if (defaultWysiwygContent == null ||
+              !defaultWysiwygContent.getLanguage().equals(ConverterUtil.defaultLanguage) &&
+                  currentWysiwygContent.getLanguage().equals(ConverterUtil.defaultLanguage)) {
+            defaultWysiwygContent = currentWysiwygContent;
+            if (firstContent == null) {
+              firstContent = defaultWysiwygContent.getContent(commonLogPart);
+            }
+          }
+          if (firstContent.equals(currentWysiwygContent.getContent(commonLogPart))) {
+            wysiwygContentsToRemove.add(currentWysiwygContent);
+          } else {
+            // Contents between languages are differents, stopping the treatment of this method.
+            return;
+          }
+        }
+      }
+      removeWysiwygContents(commonLogPart, context, defaultWysiwygContent, wysiwygContentsToRemove);
+    }
+  }
+
+  /**
+   * Renames all wysiwyg file name according to the language.
+   * @param context the context.
+   */
+  private void renameFilenames(String commonLogPart, ForeignIdProcessContext context) {
+    commonLogPart += " - wysiwyg content file name";
+    for (WysiwygContent wysiwygContent : new ArrayList<WysiwygContent>(
+        context.getWysiwygOfForeignId())) {
+      String fileNameLanguage = ConverterUtil.checkLanguage(
+          ConverterUtil.extractLanguage(wysiwygContent.getAttachment().getFilename()));
+      if (!wysiwygContent.getLanguage().equals(fileNameLanguage)) {
+        File contentToRename = new File(wysiwygContent.getAttachment().getAttachmentPath());
+        if (contentToRename.exists() && contentToRename.isFile()) {
+          wysiwygContent.getAttachment().setFilename(ConverterUtil
+              .replaceLanguage(wysiwygContent.getAttachment().getFilename(),
+                  wysiwygContent.getLanguage()));
+          File contentRenamed = new File(wysiwygContent.getAttachment().getAttachmentPath());
+          console
+              .printMessage(commonLogPart + " - doc=" + wysiwygContent.getNodeName() + ", lang=" +
+                      wysiwygContent.getLanguage() + " - " + contentToRename.getName() +
+                      " renaming to " + contentRenamed.getName()
+              );
+          if (contentRenamed.exists()) {
+            console
+                .printWarning(commonLogPart + " - doc=" + wysiwygContent.getNodeName() + ", lang=" +
+                        wysiwygContent.getLanguage() +
+                        " aborted because " + contentRenamed.getName() +
+                        " already exists! Nothing is renamed and a manual intervention " +
+                        "must be performed."
+                );
+            return;
+          }
+          service.updateAttachment(wysiwygContent.getAttachment(), contentToRename);
+          FileUtils.deleteQuietly(contentToRename);
+          context.addRenamedContent();
+        }
+      }
+    }
+  }
+
+  /**
+   * Common treatments to remove content.
+   * @param commonLogPart
+   * @param context
+   * @param wysiwygContentToKeep
+   * @param wysiwygContentsToRemove
+   */
+  private void removeWysiwygContents(String commonLogPart, ForeignIdProcessContext context,
+      WysiwygContent wysiwygContentToKeep, List<WysiwygContent> wysiwygContentsToRemove) {
+    if (wysiwygContentToKeep != null) {
+      wysiwygContentsToRemove.remove(wysiwygContentToKeep);
+      if (!wysiwygContentsToRemove.isEmpty()) {
+        console.printMessage(
+            commonLogPart + " - doc=" + wysiwygContentToKeep.getNodeName() + ", lang=" +
+                wysiwygContentToKeep.getLanguage() + " - content kept"
+        );
+        for (WysiwygContent wysiwygContentToRemove : wysiwygContentsToRemove) {
+          service.removeContent(wysiwygContentToRemove.getAttachment(),
+              wysiwygContentToRemove.getLanguage());
+          console.printMessage(
+              commonLogPart + " - doc=" + wysiwygContentToRemove.getNodeName() + ", lang=" +
+                  wysiwygContentToRemove.getLanguage() + " - content removed"
+          );
+          context.remove(wysiwygContentToRemove);
+        }
+        context.resetIndexation();
+      }
+    }
+  }
+
+  /**
+   * Gets the content of the given wysiwyg/language.
+   * @param commonLogPart
+   * @param wysiwygLangAttachment
+   * @return a String that represents the content in UTF8.
+   */
+  private String getContent(String commonLogPart, SimpleDocument wysiwygLangAttachment) {
+    ByteArrayOutputStream content = new ByteArrayOutputStream();
+    service.getBinaryContent(content, wysiwygLangAttachment.getPk(),
+        wysiwygLangAttachment.getLanguage());
+    try {
+      return content.toString(Charsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      console
+          .printError(commonLogPart + " - doc=" + wysiwygLangAttachment.getNodeName() + ", lang=" +
+              wysiwygLangAttachment.getLanguage() + " - unsupported encoding", e);
+      return UUID.randomUUID().toString();
+    }
+  }
+
+  /**
+   * Indicates if the content of given wysiwyg/language is empty.
+   * @param wysiwygLangAttachment
+   * @return true if empty, false otherwise.
+   */
+  private boolean isEmptyContent(SimpleDocument wysiwygLangAttachment) {
+    ByteArrayOutputStream content = new ByteArrayOutputStream();
+    service.getBinaryContent(content, wysiwygLangAttachment.getPk(),
+        wysiwygLangAttachment.getLanguage(), 0, 1);
+    return content.size() == 0;
+  }
+
+  /**
+   * Gets the last update date from a document.
+   * If the last update date is not explicitly known, the date of creation is returned.
+   * @param document
+   * @return
+   */
+  private static Date getLastDocumentUpdateDate(SimpleDocument document) {
+    Date lastUpdateDate = document.getUpdated();
+    if (lastUpdateDate == null) {
+      lastUpdateDate = document.getCreated();
+    }
+    return lastUpdateDate;
+  }
+
+  /**
+   * Internal class to handled a context.
+   */
+  private class ForeignIdProcessContext {
+    private int nbRemovedContent = 0;
+    private int nbRenamedContent = 0;
+    private final List<WysiwygContent> wysiwygOfForeignId = new ArrayList<WysiwygContent>();
+    private Map<String, List<WysiwygContent>> wysiwygIndexedByLangs =
+        new HashMap<String, List<WysiwygContent>>();
+
+    public ForeignIdProcessContext(List<SimpleDocument> wysiwygOfForeignId) {
+      // Firstly
+      Collections.sort(wysiwygOfForeignId, new Comparator<SimpleDocument>() {
+        @Override
+        public int compare(final SimpleDocument sd1, final SimpleDocument sd2) {
+          return getLastDocumentUpdateDate(sd2).compareTo(getLastDocumentUpdateDate(sd1));
+        }
+      });
+      for (SimpleDocument wysiwygLang : wysiwygOfForeignId) {
+        this.wysiwygOfForeignId.add(new WysiwygContent(wysiwygLang));
+      }
+      resetIndexation();
+    }
+
+    public void resetIndexation() {
+      wysiwygIndexedByLangs.clear();
+      for (WysiwygContent wysiwygContent : wysiwygOfForeignId) {
+
+        // Index by language
+        MapUtil.putAddList(wysiwygIndexedByLangs, wysiwygContent.getLanguage(), wysiwygContent);
+      }
+    }
+
+    public void remove(WysiwygContent wysiwygContent) {
+      wysiwygOfForeignId.remove(wysiwygContent);
+      addRemovedContent();
+    }
+
+    public List<WysiwygContent> getWysiwygOfForeignId() {
+      return wysiwygOfForeignId;
+    }
+
+    public Map<String, List<WysiwygContent>> getWysiwygIndexedByLangs() {
+      return wysiwygIndexedByLangs;
+    }
+
+    public int getNbRemovedContent() {
+      return nbRemovedContent;
+    }
+
+    private void addRemovedContent() {
+      this.nbRemovedContent++;
+    }
+
+    public int getNbRenamedContent() {
+      return nbRenamedContent;
+    }
+
+    private void addRenamedContent() {
+      this.nbRenamedContent++;
+    }
+  }
+
+  /**
+   * This class represents an attachment in the JCR for an instanceId, foreignId and a language.
+   */
+  private class WysiwygContent {
+    private final SimpleDocument attachment;
+    private String content = null;
+
+    public WysiwygContent(SimpleDocument wysiwygAttachment) {
+      attachment = wysiwygAttachment;
+    }
+
+    public SimpleDocument getAttachment() {
+      return attachment;
+    }
+
+    public String getContent(String commonLogPart) {
+      if (content == null) {
+        content = WysiwygDocumentPurger.this.getContent(commonLogPart, attachment);
+      }
+      return content;
+    }
+
+    public String getId() {
+      return attachment.getId();
+    }
+
+    public String getNodeName() {
+      return attachment.getNodeName();
+    }
+
+    public String getLanguage() {
+      return attachment.getLanguage();
+    }
+
+    @Override
+    public int hashCode() {
+      HashCodeBuilder hash = new HashCodeBuilder();
+      hash.append(getId());
+      hash.append(getLanguage());
+      return hash.toHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (obj == null) {
+        return false;
+      }
+      if (super.equals(obj)) {
+        return true;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      final WysiwygContent other = (WysiwygContent) obj;
+      EqualsBuilder matcher = new EqualsBuilder();
+      matcher.append(getId(), other.getId());
+      matcher.append(getLanguage(), other.getLanguage());
+      return matcher.isEquals();
+    }
+  }
+
+  /**
+   * A result.
+   */
+  public static class Result {
+    private long nbWysiwygContentPurged = 0;
+    private long nbWysiwygFilenameRenamed = 0;
+
+    public long getNbWysiwygContentPurged() {
+      return nbWysiwygContentPurged;
+    }
+
+    public void addNbWysiwygContentPurged(final long nbWysiwygContentPurgedToAdd) {
+      this.nbWysiwygContentPurged += nbWysiwygContentPurgedToAdd;
+    }
+
+    public long getNbWysiwygFilenameRenamed() {
+      return nbWysiwygFilenameRenamed;
+    }
+
+    public void addNbWysiwygFilenameRenamed(final long nbWysiwygFilenameRenamedToAdd) {
+      this.nbWysiwygFilenameRenamed += nbWysiwygFilenameRenamedToAdd;
+    }
+  }
+}

--- a/src/main/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygPurger.java
+++ b/src/main/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygPurger.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.wysiwyg.purge;
+
+import org.silverpeas.dbbuilder.dbbuilder_dl.DbBuilderDynamicPart;
+import org.silverpeas.migration.jcr.service.RepositoryManager;
+import org.silverpeas.migration.jcr.service.SimpleDocumentService;
+import org.silverpeas.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * This class handles the purge of unnecessary WYSIWYG documents registered into the Silverpeas JCR
+ * repository.
+ * Empty WYSIWYGS for a language is considered as unnecessary.
+ * When WYSIWYG content is the same for all language of a WYSIWYG document, then one is kept and
+ * the others are considered as unnecessary.
+ * All unnecessary document contents are removed from the JCR and also from the filesystem.
+ * Deleted files from the filesystem are saved.
+ */
+public class WysiwygPurger extends DbBuilderDynamicPart {
+
+  private final ExecutorService executor;
+  private final SimpleDocumentService service;
+
+  /**
+   * The default constructor.
+   * A thread pool of 10 threads is handled.
+   */
+  public WysiwygPurger() {
+    executor = Executors.newFixedThreadPool(10);
+    this.service = new SimpleDocumentService();
+  }
+
+  /**
+   * Hidden constructor used by tests.
+   * @param service
+   * @param fixedThreadPool
+   */
+  WysiwygPurger(SimpleDocumentService service, int fixedThreadPool) {
+    executor = Executors.newFixedThreadPool(fixedThreadPool);
+    this.service = service;
+  }
+
+  /**
+   * This method must be called to perform the purge treatment.
+   * A thread pool is handled.
+   * @throws Exception
+   */
+  public void purgeDocuments() throws Exception {
+    long totalNumberOfPurgedFiles = 0L;
+    long totalNumberOfRenamedFiles = 0L;
+    List<WysiwygDocumentPurger> mergers = buildWysiwygDocumentPurgers();
+    List<Future<WysiwygDocumentPurger.Result>> results = executor.invokeAll(mergers);
+    try {
+      for (Future<WysiwygDocumentPurger.Result> result : results) {
+        totalNumberOfPurgedFiles += result.get().getNbWysiwygContentPurged();
+        totalNumberOfRenamedFiles += result.get().getNbWysiwygFilenameRenamed();
+      }
+    } catch (InterruptedException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      getConsole().printError(
+          "Error during the purge or the physical WYSIWYG file renaming of wysiwyg contents " + ex,
+          ex);
+      throw ex;
+    } finally {
+      executor.shutdown();
+    }
+    getConsole().printMessage("Nb of purged wysiwyg contents : " + totalNumberOfPurgedFiles);
+    getConsole()
+        .printMessage("Nb of renamed wysiwyg content file names : " + totalNumberOfRenamedFiles);
+    if (!RepositoryManager.isIsJcrTestEnv()) {
+      this.service.shutdown();
+    }
+  }
+
+  private List<WysiwygDocumentPurger> buildWysiwygDocumentPurgers() {
+    getConsole().printMessage(
+        "All components to be parsed to find empty WYSIWYG to purged or to find wysiwyg " +
+            "file name to rename : "
+    );
+    List<String> componentIds = service.listComponentIdsWithWysiwyg();
+    List<WysiwygDocumentPurger> result = new ArrayList<WysiwygDocumentPurger>(componentIds.size());
+    for (String componentId : componentIds) {
+      if (StringUtil.isDefined(componentId)) {
+        result.add(new WysiwygDocumentPurger(componentId, service, getConsole()));
+        getConsole().printMessage(componentId + ", ");
+      }
+    }
+    getConsole().printMessage("*************************************************************");
+    return result;
+  }
+}

--- a/src/main/java/org/silverpeas/util/CollectionUtil.java
+++ b/src/main/java/org/silverpeas/util/CollectionUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Yohann Chastagnier
+ */
+public class CollectionUtil {
+
+  public static <T> List<T> asList(T... values) {
+    return new ArrayList<T>(Arrays.asList(values));
+  }
+
+  public static <T> Set<T> asSet(T... values) {
+    return new HashSet<T>(Arrays.asList(values));
+  }
+}

--- a/src/main/java/org/silverpeas/util/Console.java
+++ b/src/main/java/org/silverpeas/util/Console.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 
 /**
@@ -46,6 +47,7 @@ public class Console {
   private File logFile;
   private PrintWriter logBuffer;
   private boolean echoAsDotEnabled = true;
+  private PrintStream out = System.out;
 
   /**
    * Creates and open a console upon the specified file. All messages will be printed into the file.
@@ -111,9 +113,9 @@ public class Console {
       logBuffer.print(message);
     }
     if (echoAsDotEnabled) {
-      System.out.print(".");
+      out.print(".");
     } else {
-      System.out.println(newline + message + newline);
+      out.println(newline + message + newline);
     }
     if (!isError) {
       logger.info(message);
@@ -126,7 +128,13 @@ public class Console {
     }
   }
 
-  public synchronized void setEchoAsDotEnabled(boolean on) {
+  public synchronized Console setEchoAsDotEnabled(boolean on) {
     echoAsDotEnabled = on;
+    return this;
+  }
+
+  public Console setOut(final PrintStream out) {
+    this.out = out;
+    return this;
   }
 }

--- a/src/main/java/org/silverpeas/util/MapUtil.java
+++ b/src/main/java/org/silverpeas/util/MapUtil.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.util;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Yohann Chastagnier
+ */
+public class MapUtil {
+
+  /**
+   * Centralizes the map adding that containing collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param values
+   * @return
+   */
+  public static <K, V> Collection<V> putAddAll(final Class<? extends Collection> collectionClass,
+      Map<K, Collection<V>> map, final K key, final Collection<V> values) {
+    Collection<V> result = null;
+
+    if (values != null && !values.isEmpty()) {
+      for (V value : values) {
+        result = putAdd(collectionClass, map, key, value);
+      }
+    } else {
+      result = putAdd(collectionClass, map, key, null);
+    }
+
+    // map result (never null)
+    return result;
+  }
+
+  /**
+   * Centralizes the map adding that containing collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static <K, V> Collection<V> putAdd(final Class<? extends Collection> collectionClass,
+      Map<K, Collection<V>> map, final K key, final V value) {
+
+    if (map == null) {
+      map = new LinkedHashMap<K, Collection<V>>();
+    }
+
+    // Old value
+    Collection<V> result = map.get(key);
+    if (result == null) {
+      try {
+        result = collectionClass.newInstance();
+      } catch (final Exception myException) {
+        throw new IllegalArgumentException(myException);
+      }
+      map.put(key, result);
+    }
+
+    // adding the value
+    result.add(value);
+
+    // map result
+    return result;
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param values
+   * @return
+   */
+  public static <K, V> List<V> putAddAllList(Map<K, List<V>> map, final K key,
+      final Collection<V> values) {
+    return putAddAllList(ArrayList.class, map, key, values);
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  public static <K, V> List<V> putAddList(Map<K, List<V>> map, final K key, final V value) {
+    return putAddList(ArrayList.class, map, key, value);
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param values
+   * @return
+   */
+  public static <K, V> Set<V> putAddAllSet(Map<K, Set<V>> map, final K key,
+      final Collection<V> values) {
+    return putAddAllSet(HashSet.class, map, key, values);
+  }
+
+  /**
+   * Centralizes the map adding that containing set collections
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  public static <K, V> Set<V> putAddSet(Map<K, Set<V>> map, final K key, final V value) {
+    return putAddSet(HashSet.class, map, key, value);
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   * @param <K>
+   * @param <V>
+   * @param listClass
+   * @param map
+   * @param key
+   * @param values
+   * @return
+   */
+  public static <K, V> List<V> putAddAllList(final Class<? extends List> listClass,
+      Map<K, List<V>> map, final K key, final Collection<V> values) {
+    List<V> result = null;
+
+    if (values != null && !values.isEmpty()) {
+      for (V value : values) {
+        result = putAddList(listClass, map, key, value);
+      }
+    } else {
+      result = putAddList(listClass, map, key, null);
+    }
+
+    // map result (never null)
+    return result;
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   *
+   * @param <K>
+   * @param <V>
+   *   @param listClass
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> List<V> putAddList(final Class<? extends List> listClass,
+      Map<K, List<V>> map, final K key, final V value) {
+
+    if (map == null) {
+      map = new LinkedHashMap<K, List<V>>();
+    }
+
+    // Old value
+    List<V> result = map.get(key);
+    if (result == null) {
+      try {
+        result = listClass.newInstance();
+      } catch (final Exception myException) {
+        throw new IllegalArgumentException(myException);
+      }
+      map.put(key, result);
+    }
+
+    // adding the value
+    result.add(value);
+
+    // map result
+    return result;
+  }
+
+  /**
+   * Centralizes the map adding that containing list collections
+   * @param <K>
+   * @param <V>
+   * @param setClass
+   * @param map
+   * @param key
+   * @param values
+   * @return
+   */
+  public static <K, V> Set<V> putAddAllSet(final Class<? extends Set> setClass, Map<K, Set<V>> map,
+      final K key, final Collection<V> values) {
+    Set<V> result = null;
+
+    if (values != null && !values.isEmpty()) {
+      for (V value : values) {
+        result = putAddSet(setClass, map, key, value);
+      }
+    } else {
+      result = putAddSet(setClass, map, key, null);
+    }
+
+    // map result (never null)
+    return result;
+  }
+
+  /**
+   * Centralizes the map adding that containing set collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param setClass
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> Set<V> putAddSet(final Class<? extends Set> setClass, Map<K, Set<V>> map,
+      final K key, final V value) {
+
+    if (map == null) {
+      map = new LinkedHashMap<K, Set<V>>();
+    }
+
+    // Old value
+    Set<V> result = map.get(key);
+    if (result == null) {
+      try {
+        result = setClass.newInstance();
+      } catch (final Exception myException) {
+        throw new IllegalArgumentException(myException);
+      }
+      map.put(key, result);
+    }
+
+    // adding the value
+    result.add(value);
+
+    // map result
+    return result;
+  }
+
+  /**
+   * Centralizes the map removing that containing list collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  public static <K, V> List<V> removeValueList(final Map<K, List<V>> map, final K key, final V value) {
+    List<V> result = null;
+    if (map != null) {
+      // Old value
+      result = map.get(key);
+      if (result != null) {
+        result.remove(value);
+      }
+    }
+
+    // map result
+    return result;
+  }
+
+  /**
+   * Centralizes the map removing that containing set collections
+   *
+   * @param <K>
+   * @param <V>
+   * @param map
+   * @param key
+   * @param value
+   * @return
+   */
+  public static <K, V> Set<V> removeValueSet(final Map<K, Set<V>> map,
+      final K key, final V value) {
+
+    Set<V> result = null;
+    if (map != null) {
+
+      // Old value
+      result = map.get(key);
+      if (result != null) {
+        result.remove(value);
+      }
+    }
+
+    // map result
+    return result;
+  }
+
+  public static <K, V> boolean equals(Map<? extends K, ? extends V> left,
+      Map<? extends K, ? extends V> right) {
+    Map<K, V> onlyOnRight = new HashMap<K, V>(right);
+    for (Map.Entry<? extends K, ? extends V> entry : left.entrySet()) {
+      K leftKey = entry.getKey();
+      V leftValue = entry.getValue();
+      if (right.containsKey(leftKey)) {
+        V rightValue = onlyOnRight.remove(leftKey);
+        if (!ObjectUtils.equals(leftValue, rightValue)) {
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
+    return onlyOnRight.isEmpty();
+  }
+}

--- a/src/main/java/org/silverpeas/util/file/FileUtil.java
+++ b/src/main/java/org/silverpeas/util/file/FileUtil.java
@@ -20,18 +20,19 @@
  */
 package org.silverpeas.util.file;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.tika.Tika;
+import org.silverpeas.dbbuilder.util.Configuration;
+import org.silverpeas.util.ConfigurationHolder;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.tika.Tika;
 
-import org.silverpeas.dbbuilder.util.Configuration;
-import org.silverpeas.util.ConfigurationHolder;
 import static java.io.File.separatorChar;
 
 /**
@@ -76,8 +77,8 @@ public final class FileUtil {
 
   /**
    * ---------------------------------------------------------------------
-   * @param from
-   * @param to
+   * @param fromDir
+   * @param toDir
    * @throws IOException
    * @see
    */
@@ -87,8 +88,8 @@ public final class FileUtil {
 
   /**
    * ---------------------------------------------------------------------
-   * @param from
-   * @param to
+   * @param fromDir
+   * @param toDir
    * @throws IOException if from doesn't exist
    * @see
    */
@@ -186,5 +187,15 @@ public final class FileUtil {
       }
     }
 
+  }
+
+  /**
+   * Delete the directory if it is empty.
+   * @param directory the directory to delete if it is empty.
+   * @return true if the directory was deleted, false otherwise.
+   */
+  public static boolean deleteEmptyDir(File directory) {
+    return directory.exists() && directory.isDirectory() && directory.list() != null &&
+        directory.list().length == 0 && directory.delete();
   }
 }

--- a/src/test/java/org/silverpeas/migration/jcr/service/SimpleDocumentServiceTest.java
+++ b/src/test/java/org/silverpeas/migration/jcr/service/SimpleDocumentServiceTest.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.service;
+
+import org.apache.commons.io.Charsets;
+import org.apache.tika.mime.MimeTypes;
+import org.junit.Test;
+import org.silverpeas.migration.jcr.service.model.DocumentType;
+import org.silverpeas.migration.jcr.service.model.SimpleDocument;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentBuilder;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentPK;
+import org.silverpeas.test.jcr.JcrTest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.silverpeas.migration.jcr.service.model.DocumentType.attachment;
+import static org.silverpeas.migration.jcr.service.model.DocumentType.wysiwyg;
+
+public class SimpleDocumentServiceTest {
+
+  private static final String instanceId = "kmelia26";
+
+  /**
+   * Test of removeContent method, of class DocumentRepository.
+   * TODO The remove of versioned contents is not yet verified. A unit test must be added...
+   */
+  @Test
+  public void testRemoveContent() throws Exception {
+    new JcrSimpleDocumentServiceTest() {
+      @Override
+      public void run() throws Exception {
+        String foreignId = "node18";
+        SimpleDocument document =
+            createAttachmentForTest(defaultDocumentBuilder(foreignId).setOrder(10),
+                defaultENContentBuilder(), "This is a test");
+        SimpleDocumentPK expResult = new SimpleDocumentPK(document.getId(), instanceId);
+        assertThat(document.getPk(), is(expResult));
+        setFrData(document);
+        updateAttachmentForTest(document, "fr", "Ceci est un test");
+
+        // Vérifying the attachment exists into both of tested languages.
+        SimpleDocument enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        SimpleDocument frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        checkFrenchSimpleDocument(frDocument);
+        File enPhysicalFile = new File(enDocument.getAttachmentPath());
+        File frPhysicalFile = new File(frDocument.getAttachmentPath());
+        assertThat(enPhysicalFile.getPath(), not(is(frPhysicalFile.getPath())));
+        assertThat(enPhysicalFile.exists(), is(true));
+        assertThat(frPhysicalFile.exists(), is(true));
+
+        // Removing the FR content
+        getSimpleDocumentService().removeContent(document, "fr");
+
+        // Vérifying the attachments
+        enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), nullValue());
+        assertThat(enPhysicalFile.exists(), is(true));
+        assertThat(frPhysicalFile.exists(), is(false));
+        assertThat(frPhysicalFile.getParentFile().exists(), is(false));
+        assertThat(frPhysicalFile.getParentFile().getParentFile().exists(), is(true));
+
+        // Removing the EN content
+        getSimpleDocumentService().removeContent(document, "en");
+
+        // Vérifying the attachments
+        enDocument = getDocumentById(document.getId(), "en");
+        frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(enDocument, nullValue());
+        assertThat(frDocument, nullValue());
+        assertThat(enPhysicalFile.exists(), is(false));
+        assertThat(frPhysicalFile.exists(), is(false));
+        assertThat(frPhysicalFile.getParentFile().exists(), is(false));
+        assertThat(frPhysicalFile.getParentFile().getParentFile().exists(), is(false));
+        assertThat(frPhysicalFile.getParentFile().getParentFile().getParentFile().exists(),
+            is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of getBinaryContent method, of class DocumentRepository.
+   */
+  @Test
+  public void testGetBinaryContent() throws Exception {
+    new JcrSimpleDocumentServiceTest() {
+      @Override
+      public void run() throws Exception {
+        String foreignId = "node18";
+        SimpleDocument document =
+            createAttachmentForTest(defaultDocumentBuilder(foreignId).setOrder(10),
+                defaultENContentBuilder(), "This is a test");
+
+        ByteArrayOutputStream bibaryContent = new ByteArrayOutputStream();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("This is a test"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en", 1, 2);
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("hi"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en", 1, 50);
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("his is a test"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en", -10, 50);
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("This is a test"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "fr");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is(""));
+
+        updateAttachmentForTest(document, "fr", "Ceci est un test");
+
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("This is a test"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "fr");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("Ceci est un test"));
+
+        updateAttachmentForTest(document, "en", "A");
+        updateAttachmentForTest(document, "fr", "B");
+
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("A"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "en", 1, 4);
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is(""));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "fr");
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is("B"));
+        bibaryContent.reset();
+        getSimpleDocumentService().getBinaryContent(bibaryContent, document.getPk(), "fr", 1, 2);
+        assertThat(bibaryContent.toString(Charsets.UTF_8.name()), is(""));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listForeignIdsWithWysiwyg method, of class DocumentRepository.
+   */
+  @Test
+  public void listForeignIdsWithWysiwyg() throws Exception {
+    new JcrSimpleDocumentServiceTest() {
+      @Override
+      public void run() throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        List<String> foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+        createAttachmentForTest(
+            defaultDocumentBuilder("otherKmelia38", "fId_26").setDocumentType(wysiwyg),
+            defaultENContentBuilder(), "fId_26_en");
+
+        // One wrong WYSIWYG base name
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg("otherKmelia38");
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg("otherKmelia38");
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Adding the second WYSIWYG document (on same component)
+        SimpleDocument secondCreatedDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr");
+        createdIds.add(secondCreatedDocument.getId());
+
+        // Two WYSIWYG on one Component
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(2));
+        assertThat(foreignIds, containsInAnyOrder("fId_26", "fId_27"));
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg("otherKmelia38");
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Updating wysiwyg file name
+        setEnData(secondCreatedDocument);
+        secondCreatedDocument.setFilename(secondCreatedDocument.getFilename());
+        updateAttachmentForTest(secondCreatedDocument, "en", "fId_27_en");
+
+        // Two WYSIWYG (each one in two languages) on one Component
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg(instanceId);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(2));
+        assertThat(foreignIds, containsInAnyOrder("fId_26", "fId_27"));
+        foreignIds = getSimpleDocumentService().listForeignIdsWithWysiwyg("otherKmelia38");
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listWysiwygByForeignId method, of class DocumentRepository.
+   */
+  @Test
+  public void listWysiwygByForeignId() throws Exception {
+    new JcrSimpleDocumentServiceTest() {
+      @Override
+      public void run() throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        List<String> wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, ""));
+        assertThat(wysiwygFIdLangFilenames, notNullValue());
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_1"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_1"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_1"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+
+        // One wrong WYSIWYG base name
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_26"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_26|en|test.pdf"));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_26"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_26|en|fId_26_wysiwyg_en.txt"));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_26"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(2));
+        assertThat(wysiwygFIdLangFilenames, containsInAnyOrder("fId_26|fr|fId_26_wysiwyg_fr.txt",
+            "fId_26|en|fId_26_wysiwyg_en.txt"));
+
+        // Adding the second WYSIWYG document (on same component)
+        SimpleDocument secondCreatedDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr");
+        createdIds.add(secondCreatedDocument.getId());
+
+        // Two WYSIWYG on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_27"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_27|fr|fId_27_wysiwyg_fr.txt"));
+
+        // Updating wysiwyg file name
+        setEnData(secondCreatedDocument);
+        secondCreatedDocument.setFilename(secondCreatedDocument.getFilename());
+        updateAttachmentForTest(secondCreatedDocument, "en", "fId_27_en");
+
+        // Two WYSIWYG (each one in two languages) on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getSimpleDocumentService().listWysiwygByForeignId(instanceId, "fId_27"));
+        assertThat(wysiwygFIdLangFilenames, hasSize(2));
+        assertThat(wysiwygFIdLangFilenames,
+            contains("fId_27|fr|fId_27_wysiwyg_fr.txt", "fId_27|en|fId_27_wysiwyg_fr.txt"));
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  private List<String> extractForeignIdLanguageFilenames(List<SimpleDocument> documents) {
+    List<String> languageFilenames = new ArrayList<String>(documents.size());
+    for (SimpleDocument document : documents) {
+      languageFilenames.add(
+          document.getForeignId() + "|" + document.getLanguage() + "|" + document.getFilename());
+    }
+    return languageFilenames;
+  }
+
+  /**
+   * Executing an adapted JcrTest
+   */
+  private abstract class JcrSimpleDocumentServiceTest extends JcrTest {
+
+    protected SimpleDocumentBuilder defaultDocumentBuilder(final String foreignId) {
+      return super.defaultDocumentBuilder(instanceId, foreignId);
+    }
+
+    protected void setEnData(SimpleDocument document) {
+      document.setLanguage("en");
+      document.setContentType(MimeTypes.OCTET_STREAM);
+      document.setSize(14L);
+      document.setDescription("This is a test document");
+      document.getAttachment().setCreatedBy("0");
+    }
+
+    protected void setFrData(SimpleDocument document) {
+      document.setLanguage("fr");
+      document.setContentType(MimeTypes.PLAIN_TEXT);
+      document.setSize(28L);
+      document.setDescription("Ceci est un document de test");
+      document.getAttachment().setCreatedBy("10");
+    }
+
+    protected void checkEnglishSimpleDocument(SimpleDocument doc) {
+      assertThat(doc.getLanguage(), is("en"));
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getContentType(), is(MimeTypes.OCTET_STREAM));
+      assertThat(doc.getSize(), is(14L));
+      assertThat(doc.getDescription(), is("This is a test document"));
+      assertThat(doc.getCreatedBy(), is("0"));
+    }
+
+    protected void checkFrenchSimpleDocument(SimpleDocument doc) {
+      assertThat(doc.getLanguage(), is("fr"));
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getContentType(), is(MimeTypes.PLAIN_TEXT));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getDescription(), is("Ceci est un document de test"));
+    }
+  }
+}

--- a/src/test/java/org/silverpeas/migration/jcr/service/model/SimpleAttachmentBuilder.java
+++ b/src/test/java/org/silverpeas/migration/jcr/service/model/SimpleAttachmentBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.service.model;
+
+import java.io.File;
+import java.util.Date;
+
+public class SimpleAttachmentBuilder {
+  private String filename;
+  private String language;
+  private String title;
+  private String description;
+  private long size;
+  private String contentType;
+  private String createdBy;
+  private Date created;
+  private String xmlFormId;
+  private String updatedBy;
+  private Date updated;
+  private File file;
+
+  public SimpleAttachmentBuilder setFilename(final String filename) {
+    this.filename = filename;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setLanguage(final String language) {
+    this.language = language;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setTitle(final String title) {
+    this.title = title;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setDescription(final String description) {
+    this.description = description;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setSize(final long size) {
+    this.size = size;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setContentType(final String contentType) {
+    this.contentType = contentType;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setCreatedBy(final String createdBy) {
+    this.createdBy = createdBy;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setCreated(final Date created) {
+    this.created = created;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setXmlFormId(final String xmlFormId) {
+    this.xmlFormId = xmlFormId;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setUpdatedBy(final String updatedBy) {
+    this.updatedBy = updatedBy;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setUpdated(final Date updated) {
+    this.updated = updated;
+    return this;
+  }
+
+  public SimpleAttachmentBuilder setFile(final File file) {
+    this.file = file;
+    return this;
+  }
+
+  public SimpleAttachment build() {
+    return new SimpleAttachment(filename, language, title, description, size, contentType,
+        createdBy, created, updatedBy,updated,xmlFormId,file);
+  }
+}

--- a/src/test/java/org/silverpeas/migration/jcr/service/model/SimpleDocumentBuilder.java
+++ b/src/test/java/org/silverpeas/migration/jcr/service/model/SimpleDocumentBuilder.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.service.model;
+
+import java.util.Date;
+
+public class SimpleDocumentBuilder {
+  private SimpleDocumentPK pk;
+  private String foreignId;
+  private int order = 0;
+  private boolean versioned = false;
+  private String editedBy = null;
+  private Date reservation = null;
+  private Date alert = null;
+  private Date expiry = null;
+  private String status;
+  private String cloneId;
+  private int minorVersion = 0;
+  private int majorVersion = 0;
+  private boolean publicDocument = false;
+  private String nodeName;
+  private String comment = null;
+  private DocumentType documentType = DocumentType.attachment;
+  private String oldContext;
+  private SimpleAttachment file;
+
+  public SimpleDocumentBuilder setPk(final SimpleDocumentPK pk) {
+    this.pk = pk;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setForeignId(final String foreignId) {
+    this.foreignId = foreignId;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setOrder(final int order) {
+    this.order = order;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setVersioned(final boolean versioned) {
+    this.versioned = versioned;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setEditedBy(final String editedBy) {
+    this.editedBy = editedBy;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setReservation(final Date reservation) {
+    this.reservation = reservation;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setAlert(final Date alert) {
+    this.alert = alert;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setExpiry(final Date expiry) {
+    this.expiry = expiry;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setStatus(final String status) {
+    this.status = status;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setCloneId(final String cloneId) {
+    this.cloneId = cloneId;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setMinorVersion(final int minorVersion) {
+    this.minorVersion = minorVersion;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setMajorVersion(final int majorVersion) {
+    this.majorVersion = majorVersion;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setPublicDocument(final boolean publicDocument) {
+    this.publicDocument = publicDocument;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setNodeName(final String nodeName) {
+    this.nodeName = nodeName;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setComment(final String comment) {
+    this.comment = comment;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setDocumentType(final DocumentType documentType) {
+    this.documentType = documentType;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setOldContext(final String oldContext) {
+    this.oldContext = oldContext;
+    return this;
+  }
+
+  public SimpleDocumentBuilder setFile(final SimpleAttachment file) {
+    this.file = file;
+    return this;
+  }
+
+  public SimpleDocument build() {
+    return new SimpleDocument(pk, foreignId, order, versioned, editedBy, reservation, alert, expiry,
+        status, cloneId, minorVersion, majorVersion, publicDocument, nodeName, comment,
+        documentType, oldContext, file);
+  }
+}

--- a/src/test/java/org/silverpeas/migration/jcr/service/repository/DocumentRepositoryTest.java
+++ b/src/test/java/org/silverpeas/migration/jcr/service/repository/DocumentRepositoryTest.java
@@ -1,0 +1,1111 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.service.repository;
+
+import org.apache.commons.io.Charsets;
+import org.apache.tika.mime.MimeTypes;
+import org.junit.Test;
+import org.silverpeas.migration.jcr.service.model.DocumentType;
+import org.silverpeas.migration.jcr.service.model.SimpleAttachment;
+import org.silverpeas.migration.jcr.service.model.SimpleDocument;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentBuilder;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentPK;
+import org.silverpeas.test.jcr.JcrTest;
+
+import javax.jcr.Session;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.silverpeas.migration.jcr.service.model.DocumentType.attachment;
+import static org.silverpeas.migration.jcr.service.model.DocumentType.wysiwyg;
+
+public class DocumentRepositoryTest {
+
+  private static final String instanceId = "kmelia26";
+
+
+  /**
+   * Test of createDocument method, of class DocumentRepository.
+   */
+  @Test
+  public void testCreateDocument() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        String foreignId = "node18";
+        InputStream content = new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultENContentBuilder().build();
+        Date creationDate = attachment.getCreated();
+        SimpleDocument document = defaultDocumentBuilder(foreignId, attachment).build();
+        SimpleDocumentPK result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        SimpleDocument doc = getDocumentRepository().findDocumentById(session, expResult, "en");
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.getOldSilverpeasId(), greaterThan(0L));
+        assertThat(doc.getCreated(), is(creationDate));
+        checkEnglishSimpleDocument(doc);
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of deleteDocument method, of class DocumentRepository.
+   */
+  @Test
+  public void testDeleteDocument() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        String language = "en";
+        ByteArrayInputStream content =
+            new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultENContentBuilder().build();
+        Date creationDate = attachment.getCreated();
+        String foreignId = "node18";
+        SimpleDocument document = defaultDocumentBuilder(foreignId, attachment).build();
+        SimpleDocumentPK result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        SimpleDocument doc = getDocumentRepository().findDocumentById(session, expResult, language);
+        assertThat(doc, is(notNullValue()));
+        checkEnglishSimpleDocument(doc);
+        assertThat(doc.getOldSilverpeasId(), greaterThan(0L));
+        assertThat(doc.getCreated(), is(creationDate));
+        getDocumentRepository().deleteDocument(session, expResult);
+        doc = getDocumentRepository().findDocumentById(session, expResult, language);
+        assertThat(doc, is(nullValue()));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of findDocumentById method, of class DocumentRepository.
+   */
+  @Test
+  public void testFindDocumentById() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        ByteArrayInputStream content =
+            new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultENContentBuilder().build();
+        Date creationDate = attachment.getCreated();
+        String foreignId = "node18";
+        SimpleDocument document = defaultDocumentBuilder(foreignId, attachment).build();
+        SimpleDocumentPK result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        SimpleDocument doc = getDocumentRepository().findDocumentById(session, expResult, "en");
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.getOldSilverpeasId(), is(not(0L)));
+        assertThat(doc.getAttachment(), notNullValue());
+        assertThat(doc.getCreated(), is(creationDate));
+        checkEnglishSimpleDocument(doc);
+        doc = getDocumentRepository().findDocumentById(session, expResult, "fr");
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.getOldSilverpeasId(), is(not(0L)));
+        assertThat(doc.getAttachment(), nullValue());
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of findLast method, of class DocumentRepository.
+   */
+  @Test
+  public void testFindLast() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        String foreignId = "node18";
+        ByteArrayInputStream content =
+            new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultENContentBuilder().build();
+        SimpleDocument document =
+            defaultDocumentBuilder(foreignId, attachment).setOrder(10).build();
+        SimpleDocumentPK result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        long oldSilverpeasId = document.getOldSilverpeasId();
+        content = new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+        attachment = defaultFRContentBuilder().build();
+        foreignId = "node18";
+        document = defaultDocumentBuilder(foreignId, attachment).setOrder(5).build();
+        result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        session.save();
+        SimpleDocument doc = getDocumentRepository().findLast(session, instanceId, foreignId);
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.getOldSilverpeasId(), is(oldSilverpeasId));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of updateDocument method, of class DocumentRepository.
+   */
+  @Test
+  public void testUpdateDocument() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        ByteArrayInputStream content =
+            new ByteArrayInputStream("This is a test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultENContentBuilder().build();
+        String foreignId = "node18";
+        SimpleDocument document =
+            defaultDocumentBuilder(foreignId, attachment).setOrder(10).build();
+        SimpleDocumentPK result = getDocumentRepository().createDocument(session, document);
+        getDocumentRepository().storeContent(document, content);
+        SimpleDocumentPK expResult = new SimpleDocumentPK(result.getId(), instanceId);
+        assertThat(result, is(expResult));
+        attachment = defaultFRContentBuilder().build();
+        document = defaultDocumentBuilder(foreignId, attachment).setPk(result).setOrder(15).build();
+        getDocumentRepository().updateDocument(session, document);
+        session.save();
+        SimpleDocument doc = getDocumentRepository().findDocumentById(session, result, "fr");
+        assertThat(doc, is(notNullValue()));
+        assertThat(doc.getOrder(), is(15));
+        assertThat(doc.getContentType(), is(MimeTypes.PLAIN_TEXT));
+        assertThat(doc.getSize(), is(28L));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listComponentsWithWysiwyg method, of class DocumentRepository.
+   */
+  @Test
+  public void listComponentsWithWysiwyg() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        List<String> components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, notNullValue());
+        assertThat(components, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(0));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder(), "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en").getId();
+        createdIds.add(createdUuid);
+
+        // One WYSIWYG
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(1));
+        assertThat(components, contains(instanceId));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdUuid, "en");
+        setEnData(enDocument);
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(1));
+        assertThat(components, contains(instanceId));
+
+        // Adding the second WYSIWYG document (on same component)
+        createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder(), "fId_27_fr").getId();
+        createdIds.add(createdUuid);
+
+        // Two WYSIWYG on one Component
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(1));
+        assertThat(components, contains(instanceId));
+
+        // Adding a third WYSIWYG document (on other component that does not respect component id
+        // pattern)
+        createdUuid = createAttachmentForTest(defaultDocumentBuilder("fId_28")
+                .setPk(new SimpleDocumentPK("-1", "badInstanceIdPattern")).setDocumentType(wysiwyg),
+            defaultENContentBuilder(), "fId_28_en"
+        ).getId();
+        createdIds.add(createdUuid);
+
+        // Three WYSIWYG on two Components (one component id is not taken into account because
+        // its instanceId)
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(1));
+        assertThat(components, containsInAnyOrder(instanceId));
+
+        // Adding a fourth WYSIWYG document (on other component that respects component id
+        // pattern)
+        createdUuid = createAttachmentForTest(
+            defaultDocumentBuilder("fId_29").setPk(new SimpleDocumentPK("-1", "otherInstanceId38"))
+                .setDocumentType(wysiwyg), defaultFRContentBuilder(), "fId_29_fr"
+        ).getId();
+        createdIds.add(createdUuid);
+
+        // Number of expected created documents
+        nbDocuments = nbDocuments + 4;
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Four WYSIWYG on three Components (one component id is not taken into account because
+        // its instanceId)
+        components = getDocumentRepository().listComponentsWithWysiwyg(session);
+        assertThat(components, hasSize(2));
+        assertThat(components, containsInAnyOrder(instanceId, "otherInstanceId38"));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listWysiwygFileNames method, of class DocumentRepository.
+   */
+  @Test
+  public void listWysiwygFileNames() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        Set<String> wysiwygFilenames =
+            getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, notNullValue());
+        assertThat(wysiwygFilenames, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(0));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+
+        // One wrong WYSIWYG base name
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(0));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(1));
+        assertThat(wysiwygFilenames, contains("fId_26_wysiwyg"));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(1));
+        assertThat(wysiwygFilenames, contains("fId_26_wysiwyg"));
+
+        // Adding the second WYSIWYG document (on same component)
+        createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr")
+                .getId();
+        createdIds.add(createdUuid);
+
+        // Two WYSIWYG on one Component
+        wysiwygFilenames = getDocumentRepository().listWysiwygFileNames(session, instanceId);
+        assertThat(wysiwygFilenames, hasSize(2));
+        assertThat(wysiwygFilenames, containsInAnyOrder("fId_26_wysiwyg", "fId_27_wysiwyg"));
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listWysiwygAttachmentsByBasename method, of class DocumentRepository.
+   */
+  @Test
+  public void listWysiwygAttachmentsByBasename() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        List<String> wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, notNullValue());
+        assertThat(wysiwygLangFilenames, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(0));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+
+        // One wrong WYSIWYG base name
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(0));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(1));
+        assertThat(wysiwygLangFilenames, contains("fId_26|en|fId_26_wysiwyg_en.txt"));
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listWysiwygAttachmentsByBasename(session, instanceId, "fId_26_wysiwyg"));
+        assertThat(wysiwygLangFilenames, hasSize(1));
+        assertThat(wysiwygLangFilenames, contains("fId_26|en|fId_26_wysiwyg_en.txt"));
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listWysiwygAttachmentsByBasename(session, instanceId, "wrong_fId_26_wysiwyg"));
+        assertThat(wysiwygLangFilenames, hasSize(0));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(2));
+        assertThat(wysiwygLangFilenames, containsInAnyOrder("fId_26|en|fId_26_wysiwyg_en.txt",
+            "fId_26|fr|fId_26_wysiwyg_fr.txt"));
+
+        // Adding the second WYSIWYG document (on same component)
+        SimpleDocument secondCreatedDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr");
+        createdIds.add(secondCreatedDocument.getId());
+
+        // Two WYSIWYG on one Component
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(3));
+        assertThat(wysiwygLangFilenames,
+            containsInAnyOrder("fId_26|en|fId_26_wysiwyg_en.txt", "fId_26|fr|fId_26_wysiwyg_fr.txt",
+                "fId_27|fr|fId_27_wysiwyg_fr.txt")
+        );
+
+        // Updating wysiwyg file name
+        setEnData(secondCreatedDocument);
+        secondCreatedDocument.setFilename(secondCreatedDocument.getFilename());
+        updateAttachmentForTest(secondCreatedDocument, "en", "fId_27_en");
+
+        // Two WYSIWYG (each one in two languages) on one Component
+        wysiwygLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository().listWysiwygAttachmentsByBasename(session, instanceId, ""));
+        assertThat(wysiwygLangFilenames, hasSize(4));
+        assertThat(wysiwygLangFilenames,
+            containsInAnyOrder("fId_26|en|fId_26_wysiwyg_en.txt", "fId_26|fr|fId_26_wysiwyg_fr.txt",
+                "fId_27|fr|fId_27_wysiwyg_fr.txt", "fId_27|en|fId_27_wysiwyg_fr.txt")
+        );
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listForeignIdsByType method, of class DocumentRepository.
+   */
+  @Test
+  public void listForeignIdsByType() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        Set<String> foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, attachment);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, attachment);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_1"));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(0));
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, attachment);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(2));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+        createAttachmentForTest(
+            defaultDocumentBuilder("otherKmelia38", "fId_26").setDocumentType(wysiwyg),
+            defaultENContentBuilder(), "fId_26_en");
+
+        // One wrong WYSIWYG base name
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+        foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, "otherKmelia38", wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+        foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, "otherKmelia38", wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+        foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, "otherKmelia38", wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Adding the second WYSIWYG document (on same component)
+        SimpleDocument secondCreatedDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr");
+        createdIds.add(secondCreatedDocument.getId());
+
+        // Two WYSIWYG on one Component
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(2));
+        assertThat(foreignIds, containsInAnyOrder("fId_26", "fId_27"));
+        foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, "otherKmelia38", wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        // Updating wysiwyg file name
+        setEnData(secondCreatedDocument);
+        secondCreatedDocument.setFilename(secondCreatedDocument.getFilename());
+        updateAttachmentForTest(secondCreatedDocument, "en", "fId_27_en");
+
+        // Two WYSIWYG (each one in two languages) on one Component
+        foreignIds = getDocumentRepository().listForeignIdsByType(session, instanceId, wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(2));
+        assertThat(foreignIds, containsInAnyOrder("fId_26", "fId_27"));
+        foreignIds =
+            getDocumentRepository().listForeignIdsByType(session, "otherKmelia38", wysiwyg);
+        assertThat(foreignIds, notNullValue());
+        assertThat(foreignIds, hasSize(1));
+        assertThat(foreignIds, contains("fId_26"));
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of listAttachmentsByForeignIdAndDocumentType method, of class DocumentRepository.
+   */
+  @Test
+  public void listAttachmentsByForeignIdAndDocumentType() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        Set<String> createdIds = new HashSet<String>();
+        // No WYSIWYG content exists
+        List<String> wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(
+            getDocumentRepository()
+                .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "", wysiwyg)
+        );
+        assertThat(wysiwygFIdLangFilenames, notNullValue());
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Creating an FR "attachment" content.
+        String createdUuid =
+            createAttachmentForTest(defaultDocumentBuilder("fId_1").setDocumentType(attachment),
+                defaultFRContentBuilder(), "fId_1_fr").getId();
+        createdIds.add(createdUuid);
+        SimpleDocument enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), nullValue());
+        SimpleDocument frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_1", attachment));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_1|fr|test.odp"));
+
+        // Updating attachment with EN content.
+        setEnData(frDocument);
+        updateAttachmentForTest(frDocument, "en", "fId_1_en");
+        createdIds.add(frDocument.getId());
+
+        // Vérifying the attachment exists into both of tested languages.
+        enDocument = getDocumentById(createdUuid, "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        assertThat(enDocument.getDocumentType(), is(attachment));
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(createdUuid, "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        assertThat(frDocument.getDocumentType(), is(attachment));
+        checkFrenchSimpleDocument(frDocument);
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_1", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_1", attachment));
+        assertThat(wysiwygFIdLangFilenames, hasSize(2));
+        assertThat(wysiwygFIdLangFilenames,
+            containsInAnyOrder("fId_1|fr|test.odp", "fId_1|en|test.odp"));
+
+        // Adding several documents, but no WYSIWYG
+        Set<DocumentType> documentTypes = EnumSet.allOf(DocumentType.class);
+        documentTypes.remove(DocumentType.wysiwyg);
+        int id = 2;
+        for (DocumentType documentType : documentTypes) {
+          createdIds.add(createAttachmentForTest(
+              defaultDocumentBuilder("fId_" + id).setDocumentType(documentType),
+              defaultFRContentBuilder().setFilename("fId_" + id + "_wysiwyg_en.txt"),
+              "fId_" + id + "_fr").getId());
+          id++;
+        }
+
+        // No WYSIWYG : that is what it is expected
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_1", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(0));
+
+        // Number of expected created documents
+        int nbDocuments = 1 + (DocumentType.values().length - 1);
+        assertThat(createdIds.size(), is(nbDocuments));
+
+        // Adding the first WYSIWYG EN content
+        SimpleDocument createdDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_26").setDocumentType(wysiwyg),
+                defaultENContentBuilder(), "fId_26_en");
+        createdIds.add(createdDocument.getId());
+
+        // One wrong WYSIWYG base name
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_26", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_26|en|test.pdf"));
+
+        // Updating wysiwyg file name
+        createdDocument.setFilename("fId_26_wysiwyg_en.txt");
+        updateAttachmentForTest(createdDocument);
+
+        // One WYSIWYG base name
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_26", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_26|en|fId_26_wysiwyg_en.txt"));
+
+        // Adding the FR content to the first WYSIWYG document
+        enDocument = getDocumentById(createdDocument.getId(), "en");
+        setFrData(enDocument);
+        enDocument.setFilename("fId_26_wysiwyg_fr.txt");
+        updateAttachmentForTest(enDocument, "fr", "fId_26_fr");
+        createdIds.add(enDocument.getId());
+
+        // One WYSIWYG on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_26", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(2));
+        assertThat(wysiwygFIdLangFilenames, containsInAnyOrder("fId_26|fr|fId_26_wysiwyg_fr.txt",
+            "fId_26|en|fId_26_wysiwyg_en.txt"));
+
+        // Adding the second WYSIWYG document (on same component)
+        SimpleDocument secondCreatedDocument =
+            createAttachmentForTest(defaultDocumentBuilder("fId_27").setDocumentType(wysiwyg),
+                defaultFRContentBuilder().setFilename("fId_27_wysiwyg_fr.txt"), "fId_27_fr");
+        createdIds.add(secondCreatedDocument.getId());
+
+        // Two WYSIWYG on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_27", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(1));
+        assertThat(wysiwygFIdLangFilenames, contains("fId_27|fr|fId_27_wysiwyg_fr.txt"));
+
+        // Updating wysiwyg file name
+        setEnData(secondCreatedDocument);
+        secondCreatedDocument.setFilename(secondCreatedDocument.getFilename());
+        updateAttachmentForTest(secondCreatedDocument, "en", "fId_27_en");
+
+        // Two WYSIWYG (each one in two languages) on one Component
+        wysiwygFIdLangFilenames = extractForeignIdLanguageFilenames(getDocumentRepository()
+            .listAttachmentsByForeignIdAndDocumentType(session, instanceId, "fId_27", wysiwyg));
+        assertThat(wysiwygFIdLangFilenames, hasSize(2));
+        assertThat(wysiwygFIdLangFilenames,
+            contains("fId_27|fr|fId_27_wysiwyg_fr.txt", "fId_27|en|fId_27_wysiwyg_fr.txt"));
+
+        assertThat(createdIds, hasSize(nbDocuments + 2));
+      }
+    }.execute();
+  }
+
+  private List<String> extractForeignIdLanguageFilenames(List<SimpleDocument> documents) {
+    List<String> languageFilenames = new ArrayList<String>(documents.size());
+    for (SimpleDocument document : documents) {
+      languageFilenames.add(
+          document.getForeignId() + "|" + document.getLanguage() + "|" + document.getFilename());
+    }
+    return languageFilenames;
+  }
+
+  /**
+   * Test of addContent method, of class DocumentRepository.
+   */
+  @Test
+  public void testAddContent() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        String foreignId = "node18";
+        SimpleDocument document =
+            createAttachmentForTest(defaultDocumentBuilder(foreignId).setOrder(10),
+                defaultENContentBuilder(), "This is a test");
+        SimpleDocumentPK expResult = new SimpleDocumentPK(document.getId(), instanceId);
+        assertThat(document.getPk(), is(expResult));
+
+        // Vérifying the attachments
+        SimpleDocument enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        assertThat(new File(enDocument.getAttachmentPath()).exists(), is(true));
+        SimpleDocument frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), nullValue());
+
+        ByteArrayInputStream frContent =
+            new ByteArrayInputStream("Ceci est un test".getBytes(Charsets.UTF_8));
+        SimpleAttachment attachment = defaultFRContentBuilder().build();
+        getDocumentRepository().addContent(session, document.getPk(), attachment);
+        document.setLanguage(attachment.getLanguage());
+        getDocumentRepository().storeContent(document, frContent);
+        session.save();
+
+        // Vérifying the attachments
+        enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        assertThat(new File(enDocument.getAttachmentPath()).exists(), is(true));
+        frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        checkFrenchSimpleDocument(frDocument);
+        // This method does not add the content physically (just into JCR)
+        assertThat(new File(frDocument.getAttachmentPath()).exists(), is(false));
+      }
+    }.execute();
+  }
+
+  /**
+   * Test of removeContent method, of class DocumentRepository.
+   */
+  @Test
+  public void testRemoveContent() throws Exception {
+    new JcrDocumentRepositoryTest() {
+      @Override
+      public void run(final Session session) throws Exception {
+        String foreignId = "node18";
+        SimpleDocument document =
+            createAttachmentForTest(defaultDocumentBuilder(foreignId).setOrder(10),
+                defaultENContentBuilder(), "This is a test");
+        SimpleDocumentPK expResult = new SimpleDocumentPK(document.getId(), instanceId);
+        assertThat(document.getPk(), is(expResult));
+        setFrData(document);
+        updateAttachmentForTest(document, "fr", "Ceci est un test");
+
+        // Vérifying the attachment exists into both of tested languages.
+        SimpleDocument enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        SimpleDocument frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), notNullValue());
+        checkFrenchSimpleDocument(frDocument);
+        File enPhysicalFile = new File(enDocument.getAttachmentPath());
+        File frPhysicalFile = new File(frDocument.getAttachmentPath());
+        assertThat(enPhysicalFile.getPath(), not(is(frPhysicalFile.getPath())));
+        assertThat(enPhysicalFile.exists(), is(true));
+        assertThat(frPhysicalFile.exists(), is(true));
+
+        // Removing the FR content
+        getDocumentRepository().removeContent(session, document.getPk(), "fr");
+        session.save();
+
+        // Vérifying the attachments
+        enDocument = getDocumentById(document.getId(), "en");
+        assertThat(enDocument, notNullValue());
+        assertThat(enDocument.getAttachment(), notNullValue());
+        checkEnglishSimpleDocument(enDocument);
+        frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(frDocument, notNullValue());
+        assertThat(frDocument.getAttachment(), nullValue());
+        assertThat(enPhysicalFile.exists(), is(true));
+        // The content is just removed from JCR, not removed from the filesystem
+        assertThat(frPhysicalFile.exists(), is(true));
+
+        // Removing the EN content
+        getDocumentRepository().removeContent(session, document.getPk(), "en");
+        session.save();
+
+        // Vérifying the attachments
+        enDocument = getDocumentById(document.getId(), "en");
+        frDocument = getDocumentById(document.getId(), "fr");
+        assertThat(enDocument, nullValue());
+        assertThat(frDocument, nullValue());
+        // The content is just removed from JCR, not removed from the filesystem
+        assertThat(enPhysicalFile.exists(), is(true));
+        assertThat(frPhysicalFile.exists(), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Executing an adapted JcrTest
+   */
+  private abstract class JcrDocumentRepositoryTest extends JcrTest {
+
+    protected SimpleDocumentBuilder defaultDocumentBuilder(final String foreignId,
+        final SimpleAttachment file) {
+      return super.defaultDocumentBuilder(instanceId, foreignId, file);
+    }
+
+    protected SimpleDocumentBuilder defaultDocumentBuilder(final String foreignId) {
+      return super.defaultDocumentBuilder(instanceId, foreignId);
+    }
+
+    protected void setEnData(SimpleDocument document) {
+      document.setLanguage("en");
+      document.setContentType(MimeTypes.OCTET_STREAM);
+      document.setSize(14L);
+      document.setDescription("This is a test document");
+      document.getAttachment().setCreatedBy("0");
+    }
+
+    protected void setFrData(SimpleDocument document) {
+      document.setLanguage("fr");
+      document.setContentType(MimeTypes.PLAIN_TEXT);
+      document.setSize(28L);
+      document.setDescription("Ceci est un document de test");
+      document.getAttachment().setCreatedBy("10");
+    }
+
+    protected void checkEnglishSimpleDocument(SimpleDocument doc) {
+      assertThat(doc.getLanguage(), is("en"));
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getContentType(), is(MimeTypes.OCTET_STREAM));
+      assertThat(doc.getSize(), is(14L));
+      assertThat(doc.getDescription(), is("This is a test document"));
+      assertThat(doc.getCreatedBy(), is("0"));
+    }
+
+    protected void checkFrenchSimpleDocument(SimpleDocument doc) {
+      assertThat(doc.getLanguage(), is("fr"));
+      assertThat(doc, is(notNullValue()));
+      assertThat(doc.getContentType(), is(MimeTypes.PLAIN_TEXT));
+      assertThat(doc.getSize(), is(28L));
+      assertThat(doc.getDescription(), is("Ceci est un document de test"));
+    }
+
+    @Override
+    public void run() throws Exception {
+      Session session = openJCRSession();
+      try {
+        run(session);
+      } finally {
+        session.logout();
+      }
+    }
+
+    abstract public void run(Session session) throws Exception;
+  }
+}

--- a/src/test/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygPurgerTest.java
+++ b/src/test/java/org/silverpeas/migration/jcr/wysiwyg/purge/WysiwygPurgerTest.java
@@ -1,0 +1,728 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.migration.jcr.wysiwyg.purge;
+
+import org.apache.commons.lang.time.DateUtils;
+import org.junit.Test;
+import org.silverpeas.migration.jcr.service.ConverterUtil;
+import org.silverpeas.migration.jcr.service.model.SimpleAttachmentBuilder;
+import org.silverpeas.migration.jcr.service.model.SimpleDocument;
+import org.silverpeas.test.jcr.JcrTest;
+import org.silverpeas.util.Console;
+import org.silverpeas.util.StringUtil;
+import org.silverpeas.util.file.FileUtil;
+
+import java.io.File;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.silverpeas.migration.jcr.service.model.DocumentType.wysiwyg;
+
+public class WysiwygPurgerTest {
+
+  private final static String instanceId_A = "kmelia1";
+  private final static String foreignId_1 = "foreignId_1";
+  private final static String foreignId_2 = "foreignId_2";
+  private final static String instanceId_B = "kmelia2";
+  private final static String foreignId_11 = "foreignId_11";
+  private final static String foreignId_12 = "foreignId_12";
+  private final static String instanceId_C = "kmelia3";
+  private final static String foreignId_21 = "foreignId_21";
+  private final static String foreignId_22 = "foreignId_22";
+  private final static String instanceId_D = "kmelia4";
+  private final static String foreignId_31 = "foreignId_31";
+  private final static String foreignId_32 = "foreignId_32";
+  private final static String instanceId_E = "kmelia5";
+  private final static String foreignId_41 = "foreignId_41";
+  private final static String foreignId_42 = "foreignId_42";
+  private final static String foreignId_43 = "foreignId_43";
+  private final static String instanceId_F = "kmelia6";
+  private final static String foreignId_51 = "foreignId_51";
+  private final static String instanceId_G = "kmelia7";
+  private final static String foreignId_61 = "foreignId_61";
+  private final static String foreignId_62 = "foreignId_62";
+
+  String id_att_A_1;
+  String id_att_A_2;
+  String id_att_B_11;
+  String id_att_B_12;
+  String id_att_C_21;
+  String id_att_C_22;
+
+  @Test
+  public void testPurgeWithOtherExistingAttachment() throws Exception {
+    new JcrWysiwygPurgerTest() {
+      @Override
+      public void run() throws Exception {
+        /*
+        Preparing
+         */
+
+        // Attachment that will be kept.
+        createAttachmentsThatWillNotBeModified(this);
+
+        SimpleDocument emptyFr = createEmptyFrWysiwygForTest(instanceId_A, foreignId_1);
+        SimpleDocument emptyEn = createEmptyEnWysiwygForTest(instanceId_A, foreignId_2);
+
+        assertContent(emptyFr.getId(), "fr", "");
+        assertContent(emptyFr.getId(), "en", null);
+        assertContent(emptyEn.getId(), "fr", null);
+        assertContent(emptyEn.getId(), "en", "");
+
+        SimpleDocument filledFr = createFrWysiwygForTest(instanceId_B, foreignId_11);
+        SimpleDocument filledEn = createEnWysiwygForTest(instanceId_B, foreignId_12);
+
+        assertContent(filledFr.getId(), "fr", "fr_content_kmelia2_foreignId_11");
+        assertContent(filledFr.getId(), "en", null);
+        assertContent(filledEn.getId(), "fr", null);
+        assertContent(filledEn.getId(), "en", "en_content_kmelia2_foreignId_12");
+
+        SimpleDocument emptyFrFilledEn = createEmptyFrWysiwygForTest(instanceId_C, foreignId_21);
+        addEnWysiwygForTest(emptyFrFilledEn);
+        SimpleDocument filledFrEmptyEn = createFrWysiwygForTest(instanceId_C, foreignId_22);
+        addEmptyEnWysiwygForTest(filledFrEmptyEn);
+
+        assertContent(emptyFrFilledEn.getId(), "fr", "");
+        assertContent(emptyFrFilledEn.getId(), "en", "en_content_kmelia3_foreignId_21");
+        assertContent(filledFrEmptyEn.getId(), "fr", "fr_content_kmelia3_foreignId_22");
+        assertContent(filledFrEmptyEn.getId(), "en", "");
+
+        SimpleDocument emptyFrEmptyEn = createEmptyFrWysiwygForTest(instanceId_D, foreignId_31);
+        addEmptyEnWysiwygForTest(emptyFrEmptyEn);
+        SimpleDocument FilledEnfilledFr = createEnWysiwygForTest(instanceId_D, foreignId_32);
+        addFrWysiwygForTest(FilledEnfilledFr);
+
+        assertContent(emptyFrEmptyEn.getId(), "fr", "");
+        assertContent(emptyFrEmptyEn.getId(), "en", "");
+        assertContent(FilledEnfilledFr.getId(), "fr", "fr_content_kmelia4_foreignId_32");
+        assertContent(FilledEnfilledFr.getId(), "en", "en_content_kmelia4_foreignId_32");
+
+        SimpleDocument filledFrEmptyEnEmptyDe = createFrWysiwygForTest(instanceId_E, foreignId_41);
+        addEmptyEnWysiwygForTest(filledFrEmptyEnEmptyDe);
+        addEmptyDeWysiwygForTest(filledFrEmptyEnEmptyDe);
+        SimpleDocument sameFilledFrDeEmptyEn =
+            createFreeFrWysiwygForTest(instanceId_E, foreignId_42,
+                "same_fr-de_kmelia5_foreignId_42");
+        addEmptyEnWysiwygForTest(sameFilledFrDeEmptyEn);
+        addFreeDeWysiwygForTest(sameFilledFrDeEmptyEn, "same_fr-de_kmelia5_foreignId_42");
+        SimpleDocument sameFilledFrDeFilledEn =
+            createFreeFrWysiwygForTest(instanceId_E, foreignId_43,
+                "same_fr-de_kmelia5_foreignId_43");
+        addEnWysiwygForTest(sameFilledFrDeFilledEn);
+        addFreeDeWysiwygForTest(sameFilledFrDeFilledEn, "same_fr-de_kmelia5_foreignId_43");
+
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "fr", "fr_content_kmelia5_foreignId_41");
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "en", "");
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "de", "");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "fr", "same_fr-de_kmelia5_foreignId_42");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "en", "");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "de", "same_fr-de_kmelia5_foreignId_42");
+        assertContent(sameFilledFrDeFilledEn.getId(), "fr", "same_fr-de_kmelia5_foreignId_43");
+        assertContent(sameFilledFrDeFilledEn.getId(), "en", "en_content_kmelia5_foreignId_43");
+        assertContent(sameFilledFrDeFilledEn.getId(), "de", "same_fr-de_kmelia5_foreignId_43");
+
+        SimpleDocument sameFilledFrEn = createFreeFrWysiwygForTest(instanceId_F, foreignId_51,
+            "same_fr-en_kmelia6_foreignId_51");
+        addFreeEnWysiwygForTest(sameFilledFrEn, "same_fr-en_kmelia6_foreignId_51");
+
+        assertContent(sameFilledFrEn.getId(), "fr", "same_fr-en_kmelia6_foreignId_51");
+        assertContent(sameFilledFrEn.getId(), "en", "same_fr-en_kmelia6_foreignId_51");
+
+
+        Date aDate = java.sql.Date.valueOf("2014-06-24");
+        Date aBeforeDate = DateUtils.addDays(aDate, -4);
+        Date aAfterDate = DateUtils.addDays(aDate, 4);
+
+        SimpleDocument severalSameFilledFrFilledEn_1 =
+            createFrWysiwygForTest(instanceId_G, foreignId_61);
+        severalSameFilledFrFilledEn_1.setCreated(aDate);
+        severalSameFilledFrFilledEn_1.setUpdated(null);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_1);
+        SimpleDocument severalSameFilledFrFilledEn_1_en =
+            addEnWysiwygForTest(severalSameFilledFrFilledEn_1);
+        severalSameFilledFrFilledEn_1_en.setCreated(aDate);
+        severalSameFilledFrFilledEn_1_en.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_1_en);
+        SimpleDocument severalSameFilledFrFilledEn_2 =
+            createFrWysiwygForTest(instanceId_G, foreignId_61);
+        severalSameFilledFrFilledEn_2.setCreated(aBeforeDate);
+        severalSameFilledFrFilledEn_2.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_2);
+        SimpleDocument severalSameFilledFrFilledEn_2_en =
+            addEnWysiwygForTest(severalSameFilledFrFilledEn_2);
+        severalSameFilledFrFilledEn_2_en.setCreated(aBeforeDate);
+        severalSameFilledFrFilledEn_2_en.setUpdated(aDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_2_en);
+
+        assertThat(severalSameFilledFrFilledEn_1.getId(),
+            not(is(severalSameFilledFrFilledEn_2.getId())));
+        assertContent(severalSameFilledFrFilledEn_1.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_1.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_2.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_2.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+
+        SimpleDocument severalFilledFrFilledEnFilledDe_1 =
+            createFreeFrWysiwygForTest(instanceId_G, foreignId_62, "G_62_A");
+        severalFilledFrFilledEnFilledDe_1.setCreated(aDate);
+        severalFilledFrFilledEnFilledDe_1.setUpdated(null);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_1);
+        SimpleDocument severalFilledFrFilledEnFilled_1_en =
+            addFreeEnWysiwygForTest(severalFilledFrFilledEnFilledDe_1, "G_62_B");
+        severalFilledFrFilledEnFilled_1_en.setCreated(aDate);
+        severalFilledFrFilledEnFilled_1_en.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilled_1_en);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2 =
+            createFreeFrWysiwygForTest(instanceId_G, foreignId_62, "G_62_C");
+        severalFilledFrFilledEnFilledDe_2.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2_en =
+            addFreeEnWysiwygForTest(severalFilledFrFilledEnFilledDe_2, "G_62_D");
+        severalFilledFrFilledEnFilledDe_2_en.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2_en.setUpdated(aDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2_en);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2_de =
+            addFreeDeWysiwygForTest(severalFilledFrFilledEnFilledDe_2, "G_62_E");
+        severalFilledFrFilledEnFilledDe_2_de.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2_de.setUpdated(aDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2_de);
+        SimpleDocument severalFilledFrFilledEnFilledDe_3 =
+            createFreeDeWysiwygForTest(instanceId_G, foreignId_62, "G_62_E");
+        severalFilledFrFilledEnFilledDe_3.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_3.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_3);
+
+        assertThat(severalFilledFrFilledEnFilledDe_1.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_2.getId())));
+        assertThat(severalFilledFrFilledEnFilledDe_1.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_3.getId())));
+        assertThat(severalFilledFrFilledEnFilledDe_2.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_3.getId())));
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "fr", "G_62_A");
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "en", "G_62_B");
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "de", null);
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "fr", "G_62_C");
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "en", "G_62_D");
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "de", "G_62_E");
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "fr", null);
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "en", null);
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "de", "G_62_E");
+
+        /*
+        The test
+         */
+        WysiwygPurger purger = new WysiwygPurger(getSimpleDocumentService(), 1);
+        purger.setConsole(new Console().setEchoAsDotEnabled(false));
+        purger.purgeDocuments();
+
+        /*
+        Assertions
+         */
+
+        assertDocumentDoesNotExist(emptyFr.getId());
+        assertDocumentDoesNotExist(emptyEn.getId());
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_A)).exists(), is(true));
+
+        assertContentAndFilename(filledFr.getId(), "fr", "fr_content_kmelia2_foreignId_11");
+        assertContentAndFilename(filledFr.getId(), "en", null);
+        assertContentAndFilename(filledEn.getId(), "fr", null);
+        assertContentAndFilename(filledEn.getId(), "en", "en_content_kmelia2_foreignId_12");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_B)).exists(), is(true));
+
+        assertContentAndFilename(emptyFrFilledEn.getId(), "fr", null);
+        assertContentAndFilename(emptyFrFilledEn.getId(), "en", "en_content_kmelia3_foreignId_21");
+        assertContentAndFilename(filledFrEmptyEn.getId(), "fr", "fr_content_kmelia3_foreignId_22");
+        assertContentAndFilename(filledFrEmptyEn.getId(), "en", null);
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_C)).exists(), is(true));
+
+        assertDocumentDoesNotExist(emptyFrEmptyEn.getId());
+        assertContentAndFilename(FilledEnfilledFr.getId(), "fr", "fr_content_kmelia4_foreignId_32");
+        assertContentAndFilename(FilledEnfilledFr.getId(), "en", "en_content_kmelia4_foreignId_32");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_D)).exists(), is(true));
+
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "fr",
+            "fr_content_kmelia5_foreignId_41");
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "en", null);
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "de", null);
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "fr",
+            "same_fr-de_kmelia5_foreignId_42");
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "en", null);
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "de", null);
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "fr",
+            "same_fr-de_kmelia5_foreignId_43");
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "en",
+            "en_content_kmelia5_foreignId_43");
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "de",
+            "same_fr-de_kmelia5_foreignId_43");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_E)).exists(), is(true));
+
+        assertContentAndFilename(sameFilledFrEn.getId(), "fr", "same_fr-en_kmelia6_foreignId_51");
+        assertContentAndFilename(sameFilledFrEn.getId(), "en", null);
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_F)).exists(), is(true));
+
+        assertContentAndFilename(severalSameFilledFrFilledEn_1.getId(), "fr", null);
+        assertContentAndFilename(severalSameFilledFrFilledEn_1.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+        assertContentAndFilename(severalSameFilledFrFilledEn_2.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContentAndFilename(severalSameFilledFrFilledEn_2.getId(), "en", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "fr", "G_62_A");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "en", "G_62_B");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "de", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "fr", "G_62_C");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "en", "G_62_D");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "de", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "fr", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "en", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "de", "G_62_E");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_G)).exists(), is(true));
+
+        // Attachments that have not been modified.
+        assertAttachementsThatShouldBeNotModified(this);
+      }
+    }.execute();
+  }
+
+  @Test
+  public void testPurgeWhenOnlyWysiwygExists() throws Exception {
+    new JcrWysiwygPurgerTest() {
+      @Override
+      public void run() throws Exception {
+        /*
+        Preparing
+         */
+
+        SimpleDocument emptyFr = createEmptyFrWysiwygForTest(instanceId_A, foreignId_1);
+        SimpleDocument emptyEn = createEmptyEnWysiwygForTest(instanceId_A, foreignId_2);
+
+        assertContent(emptyFr.getId(), "fr", "");
+        assertContent(emptyFr.getId(), "en", null);
+        assertContent(emptyEn.getId(), "fr", null);
+        assertContent(emptyEn.getId(), "en", "");
+
+        SimpleDocument filledFr = createFrWysiwygForTest(instanceId_B, foreignId_11);
+        SimpleDocument filledEn = createEnWysiwygForTest(instanceId_B, foreignId_12);
+
+        assertContent(filledFr.getId(), "fr", "fr_content_kmelia2_foreignId_11");
+        assertContent(filledFr.getId(), "en", null);
+        assertContent(filledEn.getId(), "fr", null);
+        assertContent(filledEn.getId(), "en", "en_content_kmelia2_foreignId_12");
+
+        SimpleDocument emptyFrFilledEn = createEmptyFrWysiwygForTest(instanceId_C, foreignId_21);
+        addEnWysiwygForTest(emptyFrFilledEn);
+        SimpleDocument filledFrEmptyEn = createFrWysiwygForTest(instanceId_C, foreignId_22);
+        addEmptyEnWysiwygForTest(filledFrEmptyEn);
+
+        assertContent(emptyFrFilledEn.getId(), "fr", "");
+        assertContent(emptyFrFilledEn.getId(), "en", "en_content_kmelia3_foreignId_21");
+        assertContent(filledFrEmptyEn.getId(), "fr", "fr_content_kmelia3_foreignId_22");
+        assertContent(filledFrEmptyEn.getId(), "en", "");
+
+        SimpleDocument emptyFrEmptyEn = createEmptyFrWysiwygForTest(instanceId_D, foreignId_31);
+        addEmptyEnWysiwygForTest(emptyFrEmptyEn);
+        SimpleDocument FilledEnfilledFr = createEnWysiwygForTest(instanceId_D, foreignId_32);
+        addFrWysiwygForTest(FilledEnfilledFr);
+
+        assertContent(emptyFrEmptyEn.getId(), "fr", "");
+        assertContent(emptyFrEmptyEn.getId(), "en", "");
+        assertContent(FilledEnfilledFr.getId(), "fr", "fr_content_kmelia4_foreignId_32");
+        assertContent(FilledEnfilledFr.getId(), "en", "en_content_kmelia4_foreignId_32");
+
+        SimpleDocument filledFrEmptyEnEmptyDe = createFrWysiwygForTest(instanceId_E, foreignId_41);
+        addEmptyEnWysiwygForTest(filledFrEmptyEnEmptyDe);
+        addEmptyDeWysiwygForTest(filledFrEmptyEnEmptyDe);
+        SimpleDocument sameFilledFrDeEmptyEn =
+            createFreeFrWysiwygForTest(instanceId_E, foreignId_42,
+                "same_fr-de_kmelia5_foreignId_42");
+        addEmptyEnWysiwygForTest(sameFilledFrDeEmptyEn);
+        addFreeDeWysiwygForTest(sameFilledFrDeEmptyEn, "same_fr-de_kmelia5_foreignId_42");
+        SimpleDocument sameFilledFrDeFilledEn =
+            createFreeFrWysiwygForTest(instanceId_E, foreignId_43,
+                "same_fr-de_kmelia5_foreignId_43");
+        addEnWysiwygForTest(sameFilledFrDeFilledEn);
+        addFreeDeWysiwygForTest(sameFilledFrDeFilledEn, "same_fr-de_kmelia5_foreignId_43");
+
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "fr", "fr_content_kmelia5_foreignId_41");
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "en", "");
+        assertContent(filledFrEmptyEnEmptyDe.getId(), "de", "");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "fr", "same_fr-de_kmelia5_foreignId_42");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "en", "");
+        assertContent(sameFilledFrDeEmptyEn.getId(), "de", "same_fr-de_kmelia5_foreignId_42");
+        assertContent(sameFilledFrDeFilledEn.getId(), "fr", "same_fr-de_kmelia5_foreignId_43");
+        assertContent(sameFilledFrDeFilledEn.getId(), "en", "en_content_kmelia5_foreignId_43");
+        assertContent(sameFilledFrDeFilledEn.getId(), "de", "same_fr-de_kmelia5_foreignId_43");
+
+        SimpleDocument sameFilledFrEn = createFreeFrWysiwygForTest(instanceId_F, foreignId_51,
+            "same_fr-en_kmelia6_foreignId_51");
+        addFreeEnWysiwygForTest(sameFilledFrEn, "same_fr-en_kmelia6_foreignId_51");
+
+        assertContent(sameFilledFrEn.getId(), "fr", "same_fr-en_kmelia6_foreignId_51");
+        assertContent(sameFilledFrEn.getId(), "en", "same_fr-en_kmelia6_foreignId_51");
+
+
+        Date aDate = java.sql.Date.valueOf("2014-06-24");
+        Date aBeforeDate = DateUtils.addDays(aDate, -4);
+        Date aAfterDate = DateUtils.addDays(aDate, 4);
+
+        SimpleDocument severalSameFilledFrFilledEn_1 =
+            createFrWysiwygForTest(instanceId_G, foreignId_61);
+        severalSameFilledFrFilledEn_1.setCreated(aDate);
+        severalSameFilledFrFilledEn_1.setUpdated(null);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_1);
+        SimpleDocument severalSameFilledFrFilledEn_1_en =
+            addEnWysiwygForTest(severalSameFilledFrFilledEn_1);
+        severalSameFilledFrFilledEn_1_en.setCreated(aDate);
+        severalSameFilledFrFilledEn_1_en.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_1_en);
+        SimpleDocument severalSameFilledFrFilledEn_2 =
+            createFrWysiwygForTest(instanceId_G, foreignId_61);
+        severalSameFilledFrFilledEn_2.setCreated(aBeforeDate);
+        severalSameFilledFrFilledEn_2.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_2);
+        SimpleDocument severalSameFilledFrFilledEn_2_en =
+            addEnWysiwygForTest(severalSameFilledFrFilledEn_2);
+        severalSameFilledFrFilledEn_2_en.setCreated(aBeforeDate);
+        severalSameFilledFrFilledEn_2_en.setUpdated(aDate);
+        updateAttachmentForTest(severalSameFilledFrFilledEn_2_en);
+
+        assertThat(severalSameFilledFrFilledEn_1.getId(),
+            not(is(severalSameFilledFrFilledEn_2.getId())));
+        assertContent(severalSameFilledFrFilledEn_1.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_1.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_2.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContent(severalSameFilledFrFilledEn_2.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+
+        SimpleDocument severalFilledFrFilledEnFilledDe_1 =
+            createFreeFrWysiwygForTest(instanceId_G, foreignId_62, "G_62_A");
+        severalFilledFrFilledEnFilledDe_1.setCreated(aDate);
+        severalFilledFrFilledEnFilledDe_1.setUpdated(null);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_1);
+        SimpleDocument severalFilledFrFilledEnFilled_1_en =
+            addFreeEnWysiwygForTest(severalFilledFrFilledEnFilledDe_1, "G_62_B");
+        severalFilledFrFilledEnFilled_1_en.setCreated(aDate);
+        severalFilledFrFilledEnFilled_1_en.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilled_1_en);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2 =
+            createFreeFrWysiwygForTest(instanceId_G, foreignId_62, "G_62_C");
+        severalFilledFrFilledEnFilledDe_2.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2_en =
+            addFreeEnWysiwygForTest(severalFilledFrFilledEnFilledDe_2, "G_62_D");
+        severalFilledFrFilledEnFilledDe_2_en.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2_en.setUpdated(aDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2_en);
+        SimpleDocument severalFilledFrFilledEnFilledDe_2_de =
+            addFreeDeWysiwygForTest(severalFilledFrFilledEnFilledDe_2, "G_62_E");
+        severalFilledFrFilledEnFilledDe_2_de.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_2_de.setUpdated(aDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_2_de);
+        SimpleDocument severalFilledFrFilledEnFilledDe_3 =
+            createFreeDeWysiwygForTest(instanceId_G, foreignId_62, "G_62_E");
+        severalFilledFrFilledEnFilledDe_3.setCreated(aBeforeDate);
+        severalFilledFrFilledEnFilledDe_3.setUpdated(aAfterDate);
+        updateAttachmentForTest(severalFilledFrFilledEnFilledDe_3);
+
+        assertThat(severalFilledFrFilledEnFilledDe_1.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_2.getId())));
+        assertThat(severalFilledFrFilledEnFilledDe_1.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_3.getId())));
+        assertThat(severalFilledFrFilledEnFilledDe_2.getId(),
+            not(is(severalFilledFrFilledEnFilledDe_3.getId())));
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "fr", "G_62_A");
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "en", "G_62_B");
+        assertContent(severalFilledFrFilledEnFilledDe_1.getId(), "de", null);
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "fr", "G_62_C");
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "en", "G_62_D");
+        assertContent(severalFilledFrFilledEnFilledDe_2.getId(), "de", "G_62_E");
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "fr", null);
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "en", null);
+        assertContent(severalFilledFrFilledEnFilledDe_3.getId(), "de", "G_62_E");
+
+        /*
+        The test
+         */
+        WysiwygPurger purger = new WysiwygPurger(getSimpleDocumentService(), 1);
+        purger.setConsole(new Console().setEchoAsDotEnabled(false));
+        purger.purgeDocuments();
+
+        /*
+        Assertions
+         */
+
+        assertDocumentDoesNotExist(emptyFr.getId());
+        assertDocumentDoesNotExist(emptyEn.getId());
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_A)).exists(), is(false));
+
+        assertContentAndFilename(filledFr.getId(), "fr", "fr_content_kmelia2_foreignId_11");
+        assertContentAndFilename(filledFr.getId(), "en", null);
+        assertContentAndFilename(filledEn.getId(), "fr", null);
+        assertContentAndFilename(filledEn.getId(), "en", "en_content_kmelia2_foreignId_12");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_B)).exists(), is(true));
+
+        assertContentAndFilename(emptyFrFilledEn.getId(), "fr", null);
+        assertContentAndFilename(emptyFrFilledEn.getId(), "en", "en_content_kmelia3_foreignId_21");
+        assertContentAndFilename(filledFrEmptyEn.getId(), "fr", "fr_content_kmelia3_foreignId_22");
+        assertContentAndFilename(filledFrEmptyEn.getId(), "en", null);
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_C)).exists(), is(true));
+
+        assertDocumentDoesNotExist(emptyFrEmptyEn.getId());
+        assertContentAndFilename(FilledEnfilledFr.getId(), "fr", "fr_content_kmelia4_foreignId_32");
+        assertContentAndFilename(FilledEnfilledFr.getId(), "en", "en_content_kmelia4_foreignId_32");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_D)).exists(), is(true));
+
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "fr",
+            "fr_content_kmelia5_foreignId_41");
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "en", null);
+        assertContentAndFilename(filledFrEmptyEnEmptyDe.getId(), "de", null);
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "fr",
+            "same_fr-de_kmelia5_foreignId_42");
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "en", null);
+        assertContentAndFilename(sameFilledFrDeEmptyEn.getId(), "de", null);
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "fr",
+            "same_fr-de_kmelia5_foreignId_43");
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "en",
+            "en_content_kmelia5_foreignId_43");
+        assertContentAndFilename(sameFilledFrDeFilledEn.getId(), "de",
+            "same_fr-de_kmelia5_foreignId_43");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_E)).exists(), is(true));
+
+        assertContentAndFilename(sameFilledFrEn.getId(), "fr", "same_fr-en_kmelia6_foreignId_51");
+        assertContentAndFilename(sameFilledFrEn.getId(), "en", null);
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_F)).exists(), is(true));
+
+        assertContentAndFilename(severalSameFilledFrFilledEn_1.getId(), "fr", null);
+        assertContentAndFilename(severalSameFilledFrFilledEn_1.getId(), "en",
+            "en_content_kmelia7_foreignId_61");
+        assertContentAndFilename(severalSameFilledFrFilledEn_2.getId(), "fr",
+            "fr_content_kmelia7_foreignId_61");
+        assertContentAndFilename(severalSameFilledFrFilledEn_2.getId(), "en", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "fr", "G_62_A");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "en", "G_62_B");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_1.getId(), "de", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "fr", "G_62_C");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "en", "G_62_D");
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_2.getId(), "de", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "fr", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "en", null);
+        assertContentAndFilename(severalFilledFrFilledEnFilledDe_3.getId(), "de", "G_62_E");
+        assertThat(new File(FileUtil.getAbsolutePath(instanceId_G)).exists(), is(true));
+      }
+    }.execute();
+  }
+
+  /**
+   * Centralization for purge tests.
+   * @param test
+   * @throws Exception
+   */
+  private void createAttachmentsThatWillNotBeModified(JcrWysiwygPurgerTest test) throws Exception {
+    id_att_A_1 =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_A, foreignId_1),
+            test.defaultFRContentBuilder(), "").getId();
+    id_att_A_2 =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_A, foreignId_2),
+            test.defaultFRContentBuilder(), "").getId();
+    SimpleDocument simpleDocument_B =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_B, foreignId_11),
+            test.defaultFRContentBuilder(), "dummyContent");
+    id_att_B_11 = simpleDocument_B.getId();
+    test.updateAttachmentForTest(simpleDocument_B, "en", "dummyContent");
+    id_att_B_12 =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_B, foreignId_12),
+            test.defaultFRContentBuilder(), "").getId();
+    id_att_C_21 =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_C, foreignId_21),
+            test.defaultFRContentBuilder(), "").getId();
+    id_att_C_22 =
+        test.createAttachmentForTest(test.defaultDocumentBuilder(instanceId_C, foreignId_22),
+            test.defaultFRContentBuilder(), "").getId();
+  }
+
+  /**
+   * Centralization for purge tests.
+   * @param test
+   * @throws Exception
+   */
+  private void assertAttachementsThatShouldBeNotModified(JcrWysiwygPurgerTest test)
+      throws Exception {
+    SimpleDocument document_att_A_1_fr = test.getDocumentById(id_att_A_1, "fr");
+    assertThat(document_att_A_1_fr, notNullValue());
+    assertThat(document_att_A_1_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_A_1_en = test.getDocumentById(id_att_A_1, "en");
+    assertThat(document_att_A_1_en, notNullValue());
+    assertThat(document_att_A_1_en.getAttachment(), nullValue());
+    SimpleDocument document_att_A_2_fr = test.getDocumentById(id_att_A_2, "fr");
+    assertThat(document_att_A_2_fr, notNullValue());
+    assertThat(document_att_A_2_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_A_2_en = test.getDocumentById(id_att_A_2, "en");
+    assertThat(document_att_A_2_en, notNullValue());
+    assertThat(document_att_A_2_en.getAttachment(), nullValue());
+    //---
+    SimpleDocument document_att_B_11_fr = test.getDocumentById(id_att_B_11, "fr");
+    assertThat(document_att_B_11_fr, notNullValue());
+    assertThat(document_att_B_11_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_B_11_en = test.getDocumentById(id_att_B_11, "en");
+    assertThat(document_att_B_11_en, notNullValue());
+    assertThat(document_att_B_11_en.getAttachment(), notNullValue());
+    SimpleDocument document_att_B_12_fr = test.getDocumentById(id_att_B_12, "fr");
+    assertThat(document_att_B_12_fr, notNullValue());
+    assertThat(document_att_B_12_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_B_12_en = test.getDocumentById(id_att_B_12, "en");
+    assertThat(document_att_B_12_en, notNullValue());
+    assertThat(document_att_B_12_en.getAttachment(), nullValue());
+    //---
+    SimpleDocument document_att_C_21_fr = test.getDocumentById(id_att_C_21, "fr");
+    assertThat(document_att_C_21_fr, notNullValue());
+    assertThat(document_att_C_21_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_C_21_en = test.getDocumentById(id_att_C_21, "en");
+    assertThat(document_att_C_21_en, notNullValue());
+    assertThat(document_att_C_21_en.getAttachment(), nullValue());
+    SimpleDocument document_att_C_22_fr = test.getDocumentById(id_att_C_22, "fr");
+    assertThat(document_att_C_22_fr, notNullValue());
+    assertThat(document_att_C_22_fr.getAttachment(), notNullValue());
+    SimpleDocument document_att_C_22_en = test.getDocumentById(id_att_C_22, "en");
+    assertThat(document_att_C_22_en, notNullValue());
+    assertThat(document_att_C_22_en.getAttachment(), nullValue());
+  }
+
+  /**
+   * Executing an adapted JcrTest
+   */
+  private abstract class JcrWysiwygPurgerTest extends JcrTest {
+
+    public SimpleDocument assertContentAndFilename(final String uuId, final String language,
+        final String expectedContent) throws Exception {
+      SimpleDocument document = super.assertContent(uuId, language, expectedContent);
+      if (document != null && document.getAttachment() != null) {
+        String fileLanguage =
+            ConverterUtil.checkLanguage(ConverterUtil.extractLanguage(document.getFilename()));
+        assertThat(document.getFilename(), fileLanguage, is(language));
+      }
+      return document;
+    }
+
+    protected SimpleDocument createEmptyEnWysiwygForTest(String instanceId, String foreignId)
+        throws Exception {
+      return createWysiwygForTest(instanceId, foreignId, defaultENContentBuilder(), "en", "");
+    }
+
+    protected SimpleDocument createEmptyFrWysiwygForTest(String instanceId, String foreignId)
+        throws Exception {
+      return createWysiwygForTest(instanceId, foreignId, defaultFRContentBuilder(), "fr", "");
+    }
+
+    protected SimpleDocument createEnWysiwygForTest(String instanceId, String foreignId)
+        throws Exception {
+      return createWysiwygForTest(instanceId, foreignId, defaultENContentBuilder(), "en", null);
+    }
+
+    protected SimpleDocument createFrWysiwygForTest(String instanceId, String foreignId)
+        throws Exception {
+      return createWysiwygForTest(instanceId, foreignId, defaultFRContentBuilder(), "fr", null);
+    }
+
+    protected SimpleDocument createFreeFrWysiwygForTest(String instanceId, String foreignId,
+        String content) throws Exception {
+      return createWysiwygForTest(instanceId, foreignId, defaultFRContentBuilder(), "fr", content);
+    }
+
+    protected SimpleDocument createFreeDeWysiwygForTest(String instanceId, String foreignId,
+        String content) throws Exception {
+      return createWysiwygForTest(instanceId, foreignId,
+          defaultFRContentBuilder().setLanguage("de"), "de", content);
+    }
+
+    protected SimpleDocument addEmptyEnWysiwygForTest(SimpleDocument document) throws Exception {
+      return addWysiwygForTest(document, "en", "");
+    }
+
+    protected SimpleDocument addFrWysiwygForTest(SimpleDocument document) throws Exception {
+      return addWysiwygForTest(document, "fr", null);
+    }
+
+    protected SimpleDocument addEnWysiwygForTest(SimpleDocument document) throws Exception {
+      return addWysiwygForTest(document, "en", null);
+    }
+
+    protected SimpleDocument addFreeEnWysiwygForTest(SimpleDocument document, String content)
+        throws Exception {
+      return addWysiwygForTest(document, "en", content);
+    }
+
+    protected SimpleDocument addEmptyDeWysiwygForTest(SimpleDocument document) throws Exception {
+      return addWysiwygForTest(document, "de", "");
+    }
+
+    protected SimpleDocument addFreeDeWysiwygForTest(SimpleDocument document, String content)
+        throws Exception {
+      return addWysiwygForTest(document, "de", content);
+    }
+
+    private SimpleDocument addWysiwygForTest(SimpleDocument document, String language,
+        final String emptyContent) throws Exception {
+      String content = emptyContent;
+      if (!StringUtil.isDefined(content)) {
+        if (content != null && content.isEmpty()) {
+          content = "";
+        } else {
+          content =
+              language + "_content_" + document.getInstanceId() + "_" + document.getForeignId();
+        }
+      }
+      return updateAttachmentForTest(document, language, content);
+    }
+
+    private SimpleDocument createWysiwygForTest(String instanceId, String foreignId,
+        SimpleAttachmentBuilder attachmentBuilder, String language, final String emptyContent)
+        throws Exception {
+      String content = emptyContent;
+      if (!StringUtil.isDefined(content)) {
+        if (content != null && content.isEmpty()) {
+          content = "";
+        } else {
+          content = language + "_content_" + instanceId + "_" + foreignId;
+        }
+      }
+      String languageSuffix = "_" + language;
+      if (language.equals("fr") && (System.currentTimeMillis() % 10) == 0) {
+        languageSuffix = "";
+      }
+      return createAttachmentForTest(
+          defaultDocumentBuilder(instanceId, foreignId).setDocumentType(wysiwyg),
+          attachmentBuilder.setFilename(foreignId + "wysiwyg" + languageSuffix + ".txt")
+              .setSize(content.length()), content
+      );
+    }
+  }
+}

--- a/src/test/java/org/silverpeas/test/jcr/JcrTest.java
+++ b/src/test/java/org/silverpeas/test/jcr/JcrTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.test.jcr;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.tika.mime.MimeTypes;
+import org.silverpeas.migration.jcr.service.AttachmentException;
+import org.silverpeas.migration.jcr.service.RepositoryManager;
+import org.silverpeas.migration.jcr.service.SimpleDocumentService;
+import org.silverpeas.migration.jcr.service.model.SimpleAttachment;
+import org.silverpeas.migration.jcr.service.model.SimpleAttachmentBuilder;
+import org.silverpeas.migration.jcr.service.model.SimpleDocument;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentBuilder;
+import org.silverpeas.migration.jcr.service.model.SimpleDocumentPK;
+import org.silverpeas.migration.jcr.service.repository.DocumentConverter;
+import org.silverpeas.migration.jcr.service.repository.DocumentRepository;
+import org.silverpeas.test.SystemInitializationForTests;
+import org.silverpeas.util.file.FileUtil;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * This class handle a JCR test with using a String context.
+ * @author: Yohann Chastagnier
+ */
+public abstract class JcrTest {
+  private ClassPathXmlApplicationContext appContext;
+
+  private SimpleDocumentService simpleDocumentService;
+  private DocumentRepository documentRepository;
+
+
+  private final DocumentConverter converter = new DocumentConverter();
+
+  public ClassPathXmlApplicationContext getAppContext() {
+    return appContext;
+  }
+
+  public void setAppContext(final ClassPathXmlApplicationContext appContext) {
+    this.appContext = appContext;
+  }
+
+  public SimpleDocumentService getSimpleDocumentService() {
+    return simpleDocumentService;
+  }
+
+  public DocumentRepository getDocumentRepository() {
+    return documentRepository;
+  }
+
+  public Session openJCRSession() {
+    try {
+      return simpleDocumentService.getRepositoryManager().getSession();
+    } catch (RepositoryException ex) {
+      throw new AttachmentException(ex);
+    }
+  }
+
+  public abstract void run() throws Exception;
+
+
+  /**
+   * Execute the test with its context.
+   * @throws Exception
+   */
+  @SuppressWarnings("ConstantConditions")
+  public void execute() throws Exception {
+    SystemInitializationForTests.initialize();
+    setAppContext(new ClassPathXmlApplicationContext("/spring-pure-memory-jcr.xml"));
+    RepositoryManager.setIsJcrTestEnv();
+    File root = new File(new File(FileUtil.getAbsolutePath("")), "root-folder-for-jcr-repo-tests");
+    FileUtils.deleteQuietly(root.getParentFile());
+    System.setProperty("rep.home", root.getPath());
+    try {
+      File jcrXmlConf =
+          new File(JcrTest.class.getClassLoader().getResource("repository-in-memory.xml").toURI());
+      File jcrTestRepoHome = new File(root, "repository/jackrabbit");
+      FileUtils.copyFileToDirectory(jcrXmlConf, jcrTestRepoHome);
+      simpleDocumentService =
+          new SimpleDocumentService(jcrTestRepoHome.getPath(), jcrXmlConf.getPath());
+      documentRepository = simpleDocumentService.getDocumentRepository();
+      // Test
+      run();
+    } finally {
+      FileUtils.deleteQuietly(root.getParentFile());
+      shutdownJcrRepository();
+      getAppContext().close();
+    }
+  }
+
+  /**
+   * Shutdown the JCR repository.
+   */
+  protected void shutdownJcrRepository() {
+    if (simpleDocumentService != null) {
+      try {
+        simpleDocumentService.shutdown();
+      } catch (Exception e) {
+        // Jcr repository was already shutdown.
+      }
+    }
+  }
+
+  /**
+   * Common method to assert a document existence.
+   * @param uuId the uuId to retrieve the document.
+   */
+  public void assertDocumentExists(String uuId) throws Exception {
+    SimpleDocument document = getDocumentById(uuId);
+    assertThat(document, notNullValue());
+  }
+
+  /**
+   * Common method to assert a document existence.
+   * @param uuId the uuId to retrieve the document.
+   */
+  public void assertDocumentDoesNotExist(String uuId) throws Exception {
+    SimpleDocument document = getDocumentById(uuId);
+    assertThat(document, nullValue());
+  }
+
+  /**
+   * Common method to assert the content for a language of a document.
+   * @param uuId the uuId to retrieve the document.
+   * @param language the language in which the content must be verified.
+   * @param expectedContent if null, the content for the language does not exist.
+   * @return the document content loaded for the assertions.
+   */
+  public SimpleDocument assertContent(String uuId, String language, String expectedContent)
+      throws Exception {
+    SimpleDocument document = getDocumentById(uuId, language);
+    assertThat(document, notNullValue());
+    final File physicalContent;
+    if (document.getAttachment() != null) {
+      physicalContent = new File(FileUtil.getAbsolutePath(document.getInstanceId()),
+          document.getNodeName() + "/" +
+              document.getMajorVersion() + "_" + document.getMinorVersion() + "/" + language + "/" +
+              document.getFilename()
+      );
+    } else {
+      physicalContent = new File(FileUtil.getAbsolutePath(document.getInstanceId()),
+          document.getNodeName() + "/" +
+              document.getMajorVersion() + "_" + document.getMinorVersion() + "/" + language
+      );
+    }
+    if (expectedContent == null) {
+      assertThat(document.getAttachment(), nullValue());
+      assertThat(physicalContent.exists(), is(false));
+    } else {
+      assertThat(document.getAttachment(), notNullValue());
+      assertThat(document.getLanguage(), is(language));
+      assertThat(physicalContent.exists(), is(true));
+      assertThat("It must exist one file only...", physicalContent.getParentFile().listFiles(),
+          arrayWithSize(1));
+      ByteArrayOutputStream content = new ByteArrayOutputStream();
+      getSimpleDocumentService().getBinaryContent(content, document.getPk(), language);
+      assertThat(content.toString(Charsets.UTF_8.name()), is(expectedContent));
+    }
+    return document;
+  }
+
+  protected SimpleDocumentBuilder defaultDocumentBuilder(String instanceId, String foreignId,
+      SimpleAttachment file) {
+    return new SimpleDocumentBuilder().setPk(new SimpleDocumentPK("-1", instanceId))
+        .setForeignId(foreignId).setFile(file);
+  }
+
+  public SimpleDocumentBuilder defaultDocumentBuilder(String instanceId, String foreignId) {
+    return defaultDocumentBuilder(instanceId, foreignId, null);
+  }
+
+  protected SimpleAttachmentBuilder defaultENContentBuilder() {
+    return new SimpleAttachmentBuilder().setFilename("test.pdf").setLanguage("en")
+        .setTitle("My test document").setDescription("This is a test document")
+        .setSize("This is a test".getBytes(Charsets.UTF_8).length)
+        .setContentType(MimeTypes.OCTET_STREAM).setCreatedBy("0").setCreated(randomDate())
+        .setXmlFormId("18");
+
+  }
+
+  public SimpleAttachmentBuilder defaultFRContentBuilder() {
+    return new SimpleAttachmentBuilder().setFilename("test.odp").setLanguage("fr")
+        .setTitle("Mon document de test").setDescription("Ceci est un document de test")
+        .setSize(28L).setContentType(MimeTypes.PLAIN_TEXT).setCreatedBy("10")
+        .setCreated(randomDate()).setXmlFormId("5");
+  }
+
+  protected Date randomDate() {
+    long offset = Timestamp.valueOf("2014-01-01 00:00:00").getTime();
+    long end = Timestamp.valueOf("2014-04-30 00:00:00").getTime();
+    long diff = end - offset + 1;
+    return new Timestamp(offset + (long) (Math.random() * diff));
+  }
+
+  /**
+   * Creates an Image Master Node into the JCR
+   * @param sdBuilder
+   * @param saBuilder
+   * @param content
+   * @return
+   * @throws Exception
+   */
+  public SimpleDocument createAttachmentForTest(SimpleDocumentBuilder sdBuilder,
+      SimpleAttachmentBuilder saBuilder, String content) throws Exception {
+    SimpleDocument document = sdBuilder.setFile(saBuilder.build()).build();
+    return createDocumentIntoJcr(document, content);
+  }
+
+  /**
+   * Creates an Image Master Node into the JCR
+   * @param document
+   * @param language
+   * @param content
+   * @return
+   * @throws Exception
+   */
+  public SimpleDocument updateAttachmentForTest(SimpleDocument document, String language,
+      String content) throws Exception {
+    SimpleDocument documentToUpdate = document.clone();
+    documentToUpdate.setLanguage(language);
+    return updateDocumentIntoJcr(documentToUpdate, content);
+  }
+
+  /**
+   * Creates an Image Master Node into the JCR
+   * @param document
+   * @return
+   * @throws Exception
+   */
+  protected SimpleDocument updateAttachmentForTest(SimpleDocument document) throws Exception {
+    SimpleDocument documentToUpdate = document.clone();
+    return updateDocumentIntoJcr(documentToUpdate, null);
+  }
+
+  public SimpleDocument getDocumentById(String uuId, String language) throws Exception {
+    Session session = openJCRSession();
+    try {
+      return getDocumentRepository()
+          .findDocumentById(session, new SimpleDocumentPK(uuId), language);
+    } finally {
+      session.logout();
+    }
+  }
+
+  protected SimpleDocument getDocumentById(String uuId) throws Exception {
+    return getDocumentById(uuId, null);
+  }
+
+  /**
+   * Creates a master document NODE into the JCR.
+   * @param document
+   * @return
+   * @throws Exception
+   */
+  private SimpleDocument createDocumentIntoJcr(SimpleDocument document, String content)
+      throws Exception {
+    Session session = openJCRSession();
+    try {
+      SimpleDocumentPK createdPk = getDocumentRepository().createDocument(session, document);
+      session.save();
+      long contentSizeWritten = getDocumentRepository()
+          .storeContent(document, new ByteArrayInputStream(content.getBytes(Charsets.UTF_8)));
+      assertThat(contentSizeWritten, is((long) content.length()));
+      SimpleDocument createdDocument =
+          getDocumentRepository().findDocumentById(session, createdPk, document.getLanguage());
+      assertThat(createdDocument, notNullValue());
+      assertThat(createdDocument.getOrder(), is(document.getOrder()));
+      assertThat(createdDocument.getLanguage(), is(document.getLanguage()));
+      return createdDocument;
+    } finally {
+      session.logout();
+    }
+  }
+
+  /**
+   * Creates a master document NODE into the JCR.
+   * @param document
+   * @return
+   * @throws Exception
+   */
+  private SimpleDocument updateDocumentIntoJcr(SimpleDocument document, String content)
+      throws Exception {
+    assertThat(document.getPk(), notNullValue());
+    assertThat(document.getId(), not(isEmptyString()));
+    assertThat(document.getInstanceId(), not(isEmptyString()));
+    assertThat(document.getOldSilverpeasId(), greaterThan(0L));
+    Session session = openJCRSession();
+    try {
+      Node documentNode = session.getNodeByIdentifier(document.getPk().getId());
+      converter.fillNode(document, documentNode);
+      session.save();
+      if (content != null) {
+        long contentSizeWritten = getDocumentRepository()
+            .storeContent(document, new ByteArrayInputStream(content.getBytes(Charsets.UTF_8)));
+        assertThat(contentSizeWritten, is((long) content.length()));
+      }
+      SimpleDocument updatedDocument = getDocumentRepository()
+          .findDocumentById(session, document.getPk(), document.getLanguage());
+      assertThat(updatedDocument, notNullValue());
+      assertThat(updatedDocument.getLanguage(), is(document.getLanguage()));
+      return updatedDocument;
+    } finally {
+      session.logout();
+    }
+  }
+}

--- a/src/test/java/org/silverpeas/util/MapUtilTest.java
+++ b/src/test/java/org/silverpeas/util/MapUtilTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2000 - 2013 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection withWriter Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception.  You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/legal/licensing"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.silverpeas.util;
+
+import org.apache.commons.collections.ListUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class MapUtilTest {
+
+  public MapUtilTest() {
+  }
+
+  /**
+   * Test of putAddList method, of class MapUtil.
+   */
+  @Test
+  public void testPutAdd() {
+    Map<Integer, Collection<String>> map = new HashMap<Integer, Collection<String>>(2);
+    map.put(1, CollectionUtil.asList("bart"));
+    String value = "homer";
+    Collection<String> result = MapUtil.putAdd(ArrayList.class, map, 1, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result = MapUtil.putAdd(ArrayList.class, map, 2, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result, contains("lisa"));
+    assertThat(map.size(), is(2));
+  }
+
+  /**
+   * Test of putAddAllList method, of class MapUtil.
+   */
+  @Test
+  public void testPutAddAll() {
+    Map<Integer, Collection<String>> map = new HashMap<Integer, Collection<String>>(2);
+    map.put(1, CollectionUtil.asList("bart"));
+    String value = "homer";
+    Collection<String> result =
+        MapUtil.putAddAll(ArrayList.class, map, 1, CollectionUtil.asList(value));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result =
+        MapUtil.putAddAll(ArrayList.class, map, 2, CollectionUtil.asList(value + 1, value + 2));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("lisa1", "lisa2"));
+    assertThat(map.size(), is(2));
+
+    result = MapUtil.putAddAll(ArrayList.class, map, 3, new ArrayList<String>());
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(3));
+
+    result = MapUtil.putAddAll(ArrayList.class, map, 4, null);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(4));
+  }
+
+  /**
+   * Test of putAddList method, of class MapUtil.
+   */
+  @Test
+  public void testPutAddList() {
+    Map<Integer, List<String>> map = new HashMap<Integer, List<String>>(2);
+    map.put(1, CollectionUtil.asList("bart"));
+    String value = "homer";
+    List<String> result = MapUtil.putAddList(map, 1, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result = MapUtil.putAddList(map, 2, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result, contains("lisa"));
+    assertThat(map.size(), is(2));
+  }
+
+  /**
+   * Test of putAddAllList method, of class MapUtil.
+   */
+  @Test
+  public void testPutAddAllList() {
+    Map<Integer, List<String>> map = new HashMap<Integer, List<String>>(2);
+    map.put(1, CollectionUtil.asList("bart"));
+    String value = "homer";
+    List<String> result = MapUtil.putAddAllList(map, 1, CollectionUtil.asList(value));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result = MapUtil.putAddAllList(map, 2, CollectionUtil.asList(value + 1, value + 2));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, contains("lisa1", "lisa2"));
+    assertThat(map.size(), is(2));
+
+    result = MapUtil.putAddAllList(map, 3, new ArrayList<String>());
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(3));
+
+    result = MapUtil.putAddAllList(map, 4, null);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(4));
+  }
+
+  /**
+   * Test of putAddSet method, of class MapUtil.
+   */
+  @Test
+  public void testPutAddSet() {
+    Map<Integer, Set<String>> map = new HashMap<Integer, Set<String>>(2);
+    map.put(1, CollectionUtil.asSet("bart"));
+    String value = "homer";
+    Set<String> result = MapUtil.putAddSet(map, 1, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, containsInAnyOrder("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result = MapUtil.putAddSet(map, 2, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result, contains("lisa"));
+    assertThat(map.size(), is(2));
+  }
+
+  /**
+   * Test of putAddAllSet method, of class MapUtil.
+   */
+  @Test
+  public void testPutAddAllSet() {
+    Map<Integer, Set<String>> map = new HashMap<Integer, Set<String>>(2);
+    map.put(1, CollectionUtil.asSet("bart"));
+    String value = "homer";
+    Set<String> result = MapUtil.putAddAllSet(map, 1, CollectionUtil.asList(value));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, containsInAnyOrder("bart", "homer"));
+    assertThat(map.size(), is(1));
+
+    value = "lisa";
+    result = MapUtil.putAddAllSet(map, 2, CollectionUtil.asList(value + 1, value + 2));
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(2));
+    assertThat(result, containsInAnyOrder("lisa1", "lisa2"));
+    assertThat(map.size(), is(2));
+
+    result = MapUtil.putAddAllSet(map, 3, new HashSet<String>());
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(3));
+
+    result = MapUtil.putAddAllSet(map, 4, null);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result.iterator().next(), isEmptyOrNullString());
+    assertThat(map.size(), is(4));
+  }
+
+  /**
+   * Test of removeValueList method, of class MapUtil.
+   */
+  @Test
+  public void testRemoveValueList() {
+    Map<Integer, List<String>> map = new HashMap<Integer, List<String>>(2);
+    map.put(1, CollectionUtil.asList("bart", "homer"));
+    map.put(2, CollectionUtil.asList("lisa"));
+    String value = "homer";
+    List<String> result = MapUtil.removeValueList(map, 1, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result, contains("bart"));
+    assertThat(map.size(), is(2));
+
+    value = "lisa";
+    result = MapUtil.removeValueList(map, 2, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(0));
+    assertThat(map.size(), is(2));
+  }
+
+  /**
+   * Test of removeValueSet method, of class MapUtil.
+   */
+  @Test
+  public void testRemoveValueSet() {
+    Map<Integer, Set<String>> map = new HashMap<Integer, Set<String>>(2);
+    map.put(1, CollectionUtil.asSet("bart", "homer"));
+    map.put(2, CollectionUtil.asSet("lisa"));
+    String value = "homer";
+    Set<String> result = MapUtil.removeValueSet(map, 1, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(1));
+    assertThat(result, contains("bart"));
+    assertThat(map.size(), is(2));
+
+    value = "lisa";
+    result = MapUtil.removeValueSet(map, 2, value);
+    assertThat(result, is(notNullValue()));
+    assertThat(result, hasSize(0));
+    assertThat(map.size(), is(2));
+  }
+
+  /**
+   * Test of equals method, of class MapUtil.
+   */
+  @Test
+  public void testEquals() {
+    Map<Integer, String> left = new HashMap<Integer, String>(2);
+    Map<Integer, String> right = new HashMap<Integer, String>(2);
+    left.put(1, "bart");
+    left.put(2, "lisa");
+
+    right.put(1, "bart");
+    right.put(2, "lisa");
+    assertThat(MapUtil.equals(left, right), is(true));
+
+    left.remove(2);
+    assertThat(MapUtil.equals(left, right), is(false));
+
+    left.put(2, "lisa");
+    left.put(3, "homer");
+    assertThat(MapUtil.equals(left, right), is(false));
+  }
+
+}

--- a/src/test/java/org/silverpeas/util/file/FileUtilTest.java
+++ b/src/test/java/org/silverpeas/util/file/FileUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2000 - 2014 Silverpeas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * As a special exception to the terms and conditions of version 3.0 of
+ * the GPL, you may redistribute this Program in connection with Free/Libre
+ * Open Source Software ("FLOSS") applications as described in Silverpeas's
+ * FLOSS exception. You should have recieved a copy of the text describing
+ * the FLOSS exception, and it is also available here:
+ * "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.silverpeas.util.file;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class FileUtilTest {
+
+  @Test
+  public void testDeleteEmptyDir() throws IOException {
+    File root = File.createTempFile("prefix", "suffix");
+    FileUtils.deleteQuietly(root);
+    assertThat(root.exists(), is(false));
+
+    File newFile = new File(root, "aFile.txt");
+    FileUtils.touch(newFile);
+    assertThat(root.exists(), is(true));
+    assertThat(root.isDirectory(), is(true));
+    assertThat(newFile.exists(), is(true));
+    assertThat(newFile.isFile(), is(true));
+
+    assertThat(FileUtil.deleteEmptyDir(root), is(false));
+    assertThat(root.exists(), is(true));
+    assertThat(root.isDirectory(), is(true));
+    assertThat(newFile.exists(), is(true));
+    assertThat(newFile.isFile(), is(true));
+
+    assertThat(newFile.delete(), is(true));
+    assertThat(newFile.exists(), is(false));
+
+    assertThat(FileUtil.deleteEmptyDir(root), is(true));
+    assertThat(root.exists(), is(false));
+  }
+}

--- a/src/test/resources/properties/org/silverpeas/general.properties
+++ b/src/test/resources/properties/org/silverpeas/general.properties
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2000 - 2013 Silverpeas
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# As a special exception to the terms and conditions of version 3.0 of
+# the GPL, you may redistribute this Program in connection with Free/Libre
+# Open Source Software ("FLOSS") applications as described in Silverpeas's
+# FLOSS exception.  You should have recieved a copy of the text describing
+# the FLOSS exception, and it is also available here:
+# "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+ApplicationURL=/silverpeas/
+
+#Nom du workspace (configur\u00e9 dans repository.xml)
+webdav.workspace=jackrabbit
+#Mapping de la serlet webdav sans '/'
+webdav.respository=repository
+
+# working directory for components (created with the instanciators)
+uploadsPath=${basedir}/target/temp/uploads
+# working directory for the search engine
+uploadsIndexPath=${basedir}/target/temp/index
+removeLocksOnInit=yes
+# working directory for temporaries files
+tempPath=${basedir}/target/temp/temp
+
+
+# silverpeas security directory path
+securityPath=${project.build.directory}/temp/.silverpeas
+
+sessionTimeout = /admin/jsp/SessionTimeout.jsp
+accessForbidden = /admin/jsp/accessForbidden.jsp
+redirectAppInMaintenance = /admin/jsp/appInMaintenance.jsp
+
+RepositoryTypeTemp=Temp
+
+# logo to print in login page and top banner
+logo=/admin/jsp/icons/logo_silverpeasBig.gif
+smallLogo=/admin/jsp/icons/logo_silverpeas.gif
+smallLogoSilverBlue=icons/DomainbarSilverblue/logo.gif
+
+# advanced search with PDC
+# doit \u00eatre \u00e0 true ou false
+advancedSearchWithPDC = true
+
+# Domain visibility parameter
+# 0 (Default) For all visible
+# 1 Domain Silverpeas Users see all but other domain's users just see there own domain
+# 2 All users just see there own domain (except Administrators)
+domainVisibility = 0
+
+# JRE for applet Drag And Drop
+# pathInstallerJre = /weblib/dragAnddrop/jre1.4.2_11.exe
+pathInstallerJre = http://java.sun.com/update/1.5.0/jinstall-1_5_0_11-windows-i586.cab#version=1,5,0
+
+# http server base
+# Needed to override m_sAbsolute value (in front Apache installation case with port forwarding)
+# Example: http://myserver
+httpServerBase = 

--- a/src/test/resources/repository-in-memory.xml
+++ b/src/test/resources/repository-in-memory.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2000 - 2014 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception. You should have recieved a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!DOCTYPE Repository PUBLIC
+    "-//The Apache Software Foundation//DTD Jackrabbit 1.4//EN"
+    "http://jackrabbit.apache.org/dtd/repository-1.4.dtd">
+<Repository>
+  <FileSystem class="org.apache.jackrabbit.core.fs.mem.MemoryFileSystem" />
+  <Security appName="Jackrabbit">
+    <AccessManager class="org.apache.jackrabbit.core.security.SimpleAccessManager"/>
+    <LoginModule class="org.apache.jackrabbit.core.security.simple.SimpleLoginModule">
+      <param name="anonymousId" value="anonymous"/>
+      <param name="adminId" value="admin"/>
+    </LoginModule>
+  </Security>
+  <Workspaces rootPath="${rep.home}/workspaces" defaultWorkspace="${jcr.configuration.workspace}" />
+  <Workspace name="${wsp.name}">
+    <FileSystem class="org.apache.jackrabbit.core.fs.mem.MemoryFileSystem" />
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.mem.InMemBundlePersistenceManager">
+      <param name="persistent" value="false" />
+    </PersistenceManager>
+    <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
+      <param name="path" value="${wsp.home}/index" />
+      <param name="extractorPoolSize" value="2" />
+      <param name="supportHighlighting" value="true" />
+    </SearchIndex>
+  </Workspace>
+  <Versioning rootPath="${rep.home}/version">
+    <FileSystem class="org.apache.jackrabbit.core.fs.mem.MemoryFileSystem" />
+    <PersistenceManager class="org.apache.jackrabbit.core.persistence.mem.InMemBundlePersistenceManager">
+      <param name="persistent" value="false" />
+    </PersistenceManager>
+  </Versioning>
+  <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
+    <param name="path" value="${rep.home}/repository/index" />
+    <param name="extractorPoolSize " value="2" />
+    <param name="supportHighlighting" value="true" />
+  </SearchIndex>
+</Repository>

--- a/src/test/resources/spring-pure-memory-jcr.xml
+++ b/src/test/resources/spring-pure-memory-jcr.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2000 - 2014 Silverpeas
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ As a special exception to the terms and conditions of version 3.0 of
+  ~ the GPL, you may redistribute this Program in connection with Free/Libre
+  ~ Open Source Software ("FLOSS") applications as described in Silverpeas's
+  ~ FLOSS exception. You should have recieved a copy of the text describing
+  ~ the FLOSS exception, and it is also available here:
+  ~ "http://www.silverpeas.org/docs/core/legal/floss_exception.html"
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <import resource="spring-uniqueid-datasource.xml"/>
+
+  <bean id="connectionFactory" name="connectionFactory"
+        class="org.silverpeas.dbbuilder.sql.ConnectionFactory"
+        factory-method="getInstance">
+    <property name="datasource" ref="dataSource"/>
+  </bean>
+</beans>

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+jcr.configuration.workspace=jackrabbit
+
 dbbuilder.home=${silverpeas_home}
 silverpeas.home=${silverpeas_home}
 SILVERPEAS_HOME=${silverpeas_home}


### PR DESCRIPTION
(adding JCR unit tests ...)
(adding a treatment in order to rename physical WYSIWYG file name according to the language)

The commit of this PR must to be applied on 5.14.x and master version too.

Please don't forget to check the PR https://github.com/Silverpeas/Silverpeas-Core/pull/513.
