### PR TITLE
Feature #10762

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ buildscript {
 }
 
 plugins {
+  id 'java-gradle-plugin'
   id 'org.ajoberstar.grgit' version '3.0.0' apply true
   id 'idea'
   id 'maven'
@@ -112,13 +113,17 @@ dependencies {
   compile 'org.apache.commons:commons-dbcp2:2.2.0'
   compile 'commons-codec:commons-codec:1.10'
   compile 'javax.jcr:jcr:2.0'
-  compile 'org.apache.jackrabbit:jackrabbit-core:2.8.0'
+  compile 'org.apache.jackrabbit:jackrabbit-core:2.18.2'
   runtime 'org.eclipse.jetty:jetty-jndi:9.4.8.v20171121'
   runtime 'org.eclipse.jetty:jetty-util:9.4.8.v20171121'
   runtime 'com.h2database:h2:1.4.196'
   runtime 'org.postgresql:postgresql:42.1.4'
   runtime 'net.sourceforge.jtds:jtds:1.3.1'
+  testCompile gradleTestKit()
   testCompile 'junit:junit:4.12'
+  testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
+    exclude module: 'groovy-all'
+  }
 }
 
 ext {

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasSetupPlugin.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasSetupPlugin.groovy
@@ -65,6 +65,10 @@ class SilverpeasSetupPlugin implements Plugin<Project> {
     def extension = project.extensions.create(EXTENSION, SilverpeasSetupExtension, project)
     initSilverpeasSetupExtention(extension)
 
+    project.gradle.buildFinished {
+      extension.config.context.save()
+    }
+
     SilverpeasSetupService setupService = new SilverpeasSetupService(extension.config.settings)
     ManagedBeanContainer.registry()
         .register(new DataSourceProvider(extension.config.settings))
@@ -118,7 +122,7 @@ class SilverpeasSetupPlugin implements Plugin<Project> {
     Task migration = project.tasks.create(MIGRATE.name, SilverpeasMigrationTask) {
       it.migrationHome = extension.migrationHome
       it.config        = extension.config
-    }.dependsOn(configuration)
+    }.dependsOn(construction)
 
     project.tasks.create(INSTALL.name, SilverpeasInstallationTask) {
       it.deploymentDir   = extension.deploymentDir

--- a/src/main/groovy/org/silverpeas/setup/api/ManagedBeanContainer.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/ManagedBeanContainer.groovy
@@ -32,7 +32,7 @@ class ManagedBeanContainer {
   static class Registry {
 
     Registry register(def bean, String name) {
-      beans.put(name, bean)
+      beans.putIfAbsent(name, bean)
       return this
     }
 

--- a/src/test/groovy/org/silverpeas/setup/configuration/TestProperties.groovy
+++ b/src/test/groovy/org/silverpeas/setup/configuration/TestProperties.groovy
@@ -3,10 +3,10 @@ package org.silverpeas.setup.configuration
 import groovy.util.slurpersupport.GPathResult
 
 /**
- * A context of a unit test on the Silverpeas configuration.
+ * A set of properties to use in the tests on the Silverpeas configuration.
  * @author mmoquillon
  */
-class TestContext {
+class TestProperties {
 
   def settings = [
       before: [
@@ -38,10 +38,15 @@ class TestContext {
       ]
   ]
 
-  TestContext() {
+  def configContext = [
+      before: [:],
+      after: [:]
+  ]
+
+  TestProperties() {
   }
 
-  TestContext before() {
+  TestProperties before() {
     settings.before.autDomainSQL = loadPropertiesFrom('authentication/autDomainSQL.properties')
     settings.before.system = loadPropertiesFrom('systemSettings.properties')
     settings.before.scheduler = loadPropertiesFrom('workflow/engine/schedulerSettings.properties')
@@ -51,10 +56,12 @@ class TestContext {
     xmlconf.before.adefCreateProduct = loadXmlFileFrom('/data/workflowRepository/ADEFCreateProduct.xml')
     xmlconf.before.workflowDatabaseConf = loadXmlFileFrom('/resources/instanceManager/database.xml')
     xmlconf.before.workflowFastDatabaseConf = loadXmlFileFrom('/resources/instanceManager/fast_database.xml')
+
+    configContext.before = loadKeyValuesFileFrom('/configuration/.context')
     return this
   }
 
-  TestContext after() {
+  TestProperties after() {
     settings.after.autDomainSQL = loadPropertiesFrom('authentication/autDomainSQL.properties')
     settings.after.system = loadPropertiesFrom('systemSettings.properties')
     settings.after.scheduler = loadPropertiesFrom('workflow/engine/schedulerSettings.properties')
@@ -64,6 +71,8 @@ class TestContext {
     xmlconf.after.adefCreateProduct = loadXmlFileFrom('/data/workflowRepository/ADEFCreateProduct.xml')
     xmlconf.after.workflowDatabaseConf = loadXmlFileFrom('/resources/instanceManager/database.xml')
     xmlconf.after.workflowFastDatabaseConf = loadXmlFileFrom('/resources/instanceManager/fast_database.xml')
+
+    configContext.after = loadKeyValuesFileFrom('/configuration/.context')
     return this
   }
 
@@ -80,5 +89,14 @@ class TestContext {
     GPathResult result = new XmlSlurper().parse(is)
     is.close()
     return result
+  }
+
+  private Map loadKeyValuesFileFrom(String path) {
+    final Map keyValuePairs = [:]
+    getClass().getResourceAsStream(path).text.eachLine { line ->
+      String[] keyValue = line.trim().split(':')
+      keyValuePairs[keyValue[0].trim()] = keyValue[1].trim()
+    }
+    return keyValuePairs
   }
 }

--- a/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
@@ -4,7 +4,7 @@ import groovy.mock.interceptor.MockFor
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.silverpeas.setup.api.JBossServer
-import org.silverpeas.setup.test.TestSetUp
+import org.silverpeas.setup.test.TestContext
 
 import static org.silverpeas.setup.api.SilverpeasSetupTaskNames.INSTALL
 /**
@@ -14,16 +14,13 @@ import static org.silverpeas.setup.api.SilverpeasSetupTaskNames.INSTALL
 class SilverpeasInstallationTaskTest extends GroovyTestCase {
 
   private Project project
-  protected TestSetUp testSetUp
+  protected TestContext context
 
   @Override
   void setUp() {
     super.setUp()
 
-    testSetUp = TestSetUp.setUp()
-
-    System.setProperty('SILVERPEAS_HOME', testSetUp.resourcesDir)
-    System.setProperty('JBOSS_HOME', testSetUp.resourcesDir)
+    context = TestContext.create().setUpSystemEnv()
 
     project = ProjectBuilder.builder().build()
     project.apply plugin: 'silversetup'

--- a/src/test/groovy/org/silverpeas/setup/migration/AbstractDatabaseTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/migration/AbstractDatabaseTest.groovy
@@ -27,7 +27,7 @@ import groovy.sql.Sql
 import org.silverpeas.setup.api.ManagedBeanContainer
 import org.silverpeas.setup.api.SilverpeasSetupService
 import org.silverpeas.setup.test.DatabaseSetUp
-import org.silverpeas.setup.test.TestSetUp
+import org.silverpeas.setup.test.TestContext
 /**
  * The common class for all test cases about a database migration.
  * @author mmoquillon
@@ -35,7 +35,7 @@ import org.silverpeas.setup.test.TestSetUp
 abstract class AbstractDatabaseTest extends GroovyTestCase {
 
   protected DatabaseSetUp databaseSetUp
-  protected TestSetUp testSetUp
+  protected TestContext context
 
   DatabaseSetUp initDatabaseSetUp() {
     return DatabaseSetUp.setUp(withDatasource: true).createSrPackagesTable()
@@ -44,7 +44,7 @@ abstract class AbstractDatabaseTest extends GroovyTestCase {
   @Override
   void setUp() {
     super.setUp()
-    testSetUp = TestSetUp.setUp()
+    context = TestContext.create()
     databaseSetUp = initDatabaseSetUp()
     ManagedBeanContainer.registry().register(new SilverpeasSetupService([:]))
   }
@@ -57,7 +57,7 @@ abstract class AbstractDatabaseTest extends GroovyTestCase {
 
   def prepareInitialData(String module, String version) {
     databaseSetUp.prepare { Sql sql ->
-      sql.executeScript("${testSetUp.migrationHome}/db/h2/${module}/${version}/create_table.sql")
+      sql.executeScript("${context.migrationHome}/db/h2/${module}/${version}/create_table.sql")
       sql.executeUpdate("INSERT INTO sr_packages (sr_package, sr_version) VALUES (:module, :version)",
           [module: module, version: version])
     }

--- a/src/test/groovy/org/silverpeas/setup/migration/DatasourceMigrationTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/migration/DatasourceMigrationTest.groovy
@@ -44,7 +44,7 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert versionOfModule(databaseSetUp.sql, 'toto') == null
 
     Script script = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/db/h2/toto/002/create_table.sql")
+        .fromScript("${context.migrationHome}/db/h2/toto/002/create_table.sql")
         .ofType(sql)
         .build()
     DatasourceMigration migration = DatasourceMigration.builder()
@@ -64,7 +64,7 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert versionOfModule(databaseSetUp.sql, 'toto') == '002'
 
     Script script = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/db/h2/toto/up002/update.sql")
+        .fromScript("${context.migrationHome}/db/h2/toto/up002/update.sql")
         .ofType(sql)
         .build()
     DatasourceMigration migration = DatasourceMigration.builder()
@@ -86,7 +86,7 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert numberOfItems(databaseSetUp.sql, 'Person') == 0
 
     Script script = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/scripts/toto/up003/update.groovy")
+        .fromScript("${context.migrationHome}/scripts/toto/up003/update.groovy")
         .ofType(groovy)
         .build()
     DatasourceMigration migration = DatasourceMigration.builder()
@@ -109,11 +109,11 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert numberOfItems(databaseSetUp.sql, 'Person') == 0
 
     Script sqlScript = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/db/h2/toto/up003/create_table.sql")
+        .fromScript("${context.migrationHome}/db/h2/toto/up003/create_table.sql")
         .ofType(sql)
         .build()
     Script groovyScript = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/scripts/toto/up003/update.groovy")
+        .fromScript("${context.migrationHome}/scripts/toto/up003/update.groovy")
         .ofType(groovy)
         .build()
     DatasourceMigration migration = DatasourceMigration.builder()
@@ -134,7 +134,7 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert versionOfModule(databaseSetUp.sql, 'foo') == null
 
     Script script = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/db//h2/foo/002/create_table.sql")
+        .fromScript("${context.migrationHome}/db//h2/foo/002/create_table.sql")
         .ofType(sql)
         .build()
 
@@ -157,7 +157,7 @@ class DatasourceMigrationTest extends AbstractDatabaseTest {
     assert versionOfModule(databaseSetUp.sql, 'foo') == '003'
 
     Script script = MigrationScriptBuilder
-        .fromScript("${testSetUp.migrationHome}/scripts/foo/up002/update.groovy")
+        .fromScript("${context.migrationHome}/scripts/foo/up002/update.groovy")
         .ofType(groovy)
         .build()
 

--- a/src/test/groovy/org/silverpeas/setup/migration/JcrRepositoryTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/migration/JcrRepositoryTest.groovy
@@ -2,13 +2,11 @@ package org.silverpeas.setup.migration
 
 import org.silverpeas.setup.api.JcrRepositoryFactory
 import org.silverpeas.setup.test.DatabaseSetUp
-import org.silverpeas.setup.test.TestSetUp
+import org.silverpeas.setup.test.TestContext
 
 import javax.jcr.Repository
 import javax.jcr.Session
 import javax.jcr.SimpleCredentials
-import javax.naming.InitialContext
-import javax.naming.NameNotFoundException
 
 /**
  * Test case on the JCR repository fetching.
@@ -17,18 +15,23 @@ import javax.naming.NameNotFoundException
 class JcrRepositoryTest extends GroovyTestCase {
 
   private DatabaseSetUp databaseSetUp
-  private TestSetUp testSetUp
+  private TestContext context
 
   @Override
   void setUp() {
     super.setUp()
-    testSetUp = TestSetUp.setUp()
+    context = TestContext.create()
     databaseSetUp = DatabaseSetUp.setUp(withDatasource: true)
+  }
+
+  @Override
+  void tearDown() {
+    databaseSetUp.dropAll()
   }
 
   void testRepositoryAccess() {
     Repository repository =
-        JcrRepositoryFactory.instance.createRepository([SILVERPEAS_HOME: testSetUp.resourcesDir])
+        JcrRepositoryFactory.instance.createRepository([SILVERPEAS_HOME: context.resourcesDir])
     assert repository != null
 
     Session session = repository.login(new SimpleCredentials("admin", "admin".toCharArray()))

--- a/src/test/groovy/org/silverpeas/setup/migration/MigrationModuleTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/migration/MigrationModuleTest.groovy
@@ -39,10 +39,10 @@ class MigrationModuleTest extends AbstractDatabaseTest{
     assert versionOfModule(databaseSetUp.sql, 'toto') == null
 
     MigrationModule module = new MigrationModule()
-        .withSettings([MIGRATION_HOME: testSetUp.migrationHome, DB_SERVERTYPE: 'H2'])
+        .withSettings([MIGRATION_HOME: context.migrationHome, DB_SERVERTYPE: 'H2'])
         .withStatus([:])
         .withLogger(FileLogger.getLogger(getClass().getSimpleName()))
-        .loadMigrationsFrom(new File("${testSetUp.migrationHome}/modules/toto-migration.xml"))
+        .loadMigrationsFrom(new File("${context.migrationHome}/modules/toto-migration.xml"))
     module.migrate()
 
     assert versionOfModule(databaseSetUp.sql, 'toto') == '004'
@@ -54,10 +54,10 @@ class MigrationModuleTest extends AbstractDatabaseTest{
     assert numberOfItems(databaseSetUp.sql, 'Person') == 0
 
     MigrationModule module = new MigrationModule()
-        .withSettings([MIGRATION_HOME: testSetUp.migrationHome, DB_SERVERTYPE: 'H2'])
+        .withSettings([MIGRATION_HOME: context.migrationHome, DB_SERVERTYPE: 'H2'])
         .withStatus(['toto':'002'])
         .withLogger(FileLogger.getLogger(getClass().getSimpleName()))
-        .loadMigrationsFrom(new File("${testSetUp.migrationHome}/modules/toto-migration.xml"))
+        .loadMigrationsFrom(new File("${context.migrationHome}/modules/toto-migration.xml"))
     module.migrate()
 
     assert versionOfModule(databaseSetUp.sql, 'toto') == '004'
@@ -70,10 +70,10 @@ class MigrationModuleTest extends AbstractDatabaseTest{
     assert numberOfItems(databaseSetUp.sql, 'Person') == 0
 
     MigrationModule module = new MigrationModule()
-        .withSettings([MIGRATION_HOME:testSetUp.migrationHome, DB_SERVERTYPE: 'H2'])
+        .withSettings([MIGRATION_HOME:context.migrationHome, DB_SERVERTYPE: 'H2'])
         .withStatus(['toto':'003'])
         .withLogger(FileLogger.getLogger(getClass().getSimpleName()))
-        .loadMigrationsFrom(new File("${testSetUp.migrationHome}/modules/toto-migration.xml"))
+        .loadMigrationsFrom(new File("${context.migrationHome}/modules/toto-migration.xml"))
     module.migrate()
 
     assert versionOfModule(databaseSetUp.sql, 'toto') == '004'
@@ -83,10 +83,10 @@ class MigrationModuleTest extends AbstractDatabaseTest{
   void testAMalformedMigrationDescriptor() {
     shouldFail(SAXParseException) {
       new MigrationModule()
-          .withSettings([MIGRATION_HOME:testSetUp.migrationHome, DB_SERVERTYPE: 'H2'])
+          .withSettings([MIGRATION_HOME:context.migrationHome, DB_SERVERTYPE: 'H2'])
           .withStatus(['toto':'003'])
           .withLogger(FileLogger.getLogger(getClass().getSimpleName()))
-          .loadMigrationsFrom(new File("${testSetUp.migrationHome}/malformed-migration.xml"))
+          .loadMigrationsFrom(new File("${context.migrationHome}/malformed-migration.xml"))
     }
   }
 

--- a/src/test/groovy/org/silverpeas/setup/migration/SilverpeasMigrationTaskTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/migration/SilverpeasMigrationTaskTest.groovy
@@ -6,6 +6,7 @@ import org.silverpeas.setup.test.DatabaseSetUp
 
 import static org.silverpeas.setup.api.SilverpeasSetupTaskNames.MIGRATE
 import static org.silverpeas.setup.test.Assertion.versionOfModule
+
 /**
  * Test the case of the migration of the data sources performed by a dedicated Gradle task.
  * @author mmoquillon
@@ -22,8 +23,7 @@ class SilverpeasMigrationTaskTest extends AbstractDatabaseTest {
   @Override
   void setUp() {
     super.setUp()
-    System.setProperty('SILVERPEAS_HOME', testSetUp.resourcesDir)
-    System.setProperty('JBOSS_HOME', testSetUp.resourcesDir)
+    context.setUpSystemEnv()
 
     project = ProjectBuilder.builder().build()
     project.apply plugin: 'silversetup'

--- a/src/test/resources/configuration/.context
+++ b/src/test/resources/configuration/.context
@@ -1,0 +1,3 @@
+status is: updated
+installed at: 2019-07-05T17:36:56.261
+updated at: 2019-07-05T17:36:56.261

--- a/src/test/resources/configuration/silverpeas/configContextHandling.groovy
+++ b/src/test/resources/configuration/silverpeas/configContextHandling.groovy
@@ -1,0 +1,5 @@
+import java.time.LocalDate
+
+println 'Handle the configuration context'
+
+settings.context['context handled at'] = LocalDate.now().toString()


### PR DESCRIPTION
Define a new object in SilverpeasConfigurationProperties: Context.
This object defines a configuration context that can be used by any components
implied in a task of SilverSetup as well by any scripts executed by those
tasks. The context is publicly available in the settings global variable and it
is represented by a Map. Once the build is finished, the properties set in the
context are then persisted into the file SILVERPEAS_HOME/configuration/.config.

The goal of the Context object is to allow any scripts and components used in
tasks to keep track of any configuration, migration or installation context so
that they can adapt their behaviour at the next execution.

Don't forget to merge also https://github.com/Silverpeas/Silverpeas-Distribution/pull/4