### PR TITLE
Bug #10769

### DIFF
--- a/src/main/groovy/org/silverpeas/setup/SilverpeasConfigurationProperties.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasConfigurationProperties.groovy
@@ -63,12 +63,6 @@ class SilverpeasConfigurationProperties {
   final Property<File> jbossModulesDir
 
   /**
-   * The Silverpeas settings as defined in the <code>config.properties</code> file.
-   * Some of them are computed from the properties in the file <code>config.properties</code>.
-   */
-  final Map settings = [:]
-
-  /**
    * Context of a configuration process of Silverpeas: it is a set of context properties left to the
    * discretion of the different steps executed in the configuration. The context is serialized so
    * that it can be retrieved in the next configuration process by the different steps so that they
@@ -90,17 +84,11 @@ class SilverpeasConfigurationProperties {
     jbossModulesDir = project.objects.property(File)
     jbossModulesDir.set(new File(jbossConfigurationDir.get(), 'modules'))
 
-    context = new Context(configurationHome.get(), settings)
-  }
-
-  void setSettings(final Map configProperties) {
-    this.settings.putAll(configProperties)
+    context = new Context(configurationHome.get())
   }
 
   /**
-   * Context of a configuration process. It sets in the settings variable (that is shared by all
-   * the steps implied within a configuration of Silverpeas) the peculiar <code>context</code>
-   * attribute that is a dictionary of all the context properties the steps can set for their usage.
+   * Context of a configuration process.
    */
   static class Context {
     final private File file
@@ -109,18 +97,19 @@ class SilverpeasConfigurationProperties {
     /**
      * Constructs a new configuration context.
      * @param storageDir the directory into which the context will be saved.
-     * @param settings the dictionary to use to store the context properties. A peculiar
-     * <code>context</code> key will be put with as values a Map object.
      */
-    private Context(File storageDir, final Map settings) {
+    private Context(File storageDir) {
       file = new File(storageDir, '.context')
-      settings.context = props
       if (Files.exists(file.toPath())) {
         file.text.eachLine { line ->
           String[] keyValue = line.trim().split(':')
           props[keyValue[0].trim()] = keyValue[1].trim()
         }
       }
+    }
+
+    Map properties() {
+      return props
     }
 
     void save() {

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasConfigurationProperties.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasConfigurationProperties.groovy
@@ -24,6 +24,7 @@
 package org.silverpeas.setup
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 
 import javax.inject.Inject
 import java.nio.file.Files
@@ -38,35 +39,28 @@ class SilverpeasConfigurationProperties {
 
   /**
    * The home configuration directory of Silverpeas. It should contain both the global
-   * configuration properties, the Silverpeas and the JBoss configuration directory. It is expected
-   * to contain two subdirectories:
-   * <ul>
-   *   <li><code>jboss</code> with the scripts to configure JBoss/Wildfly for Silverpeas;</li>
-   *   <li><code>silverpeas</code> with the scripts to configure Silverpeas itself.</li>
-   * </ul>
-   * By default, the configuration home directory is expected to be
-   * <code>SILVERPEAS_HOME/configuration</code> where <code>SILVERPEAS_HOME</code> is the
-   * Silverpeas installation directory.
+   * configuration properties, the Silverpeas and the JBoss configuration directory. By default
+   * SILVERPEAS_HOME/configuration.
    */
-  File configurationHome
+  final Property<File> configurationHome
 
   /**
    * The directory that contains all the configuration scripts to configure JBoss/Wildfly for
-   * Silverpeas.
+   * Silverpeas. By default SILVERPEAS_HOME/configuration/jboss.
    */
-  final File jbossConfigurationDir
+  final Property<File> jbossConfigurationDir
 
   /**
    * The directory that contains all the configuration scripts to configure specifically the
-   * Silverpeas web portal and components.
+   * Silverpeas web portal and components. By default SILVERPEAS_HOME/configuration/silverpeas.
    */
-  final File silverpeasConfigurationDir
+  final Property<File> silverpeasConfigurationDir
 
   /**
    * The directory that contains the additional JBoss/Wildfly modules to install in JBoss/Wildfy
-   * for Silverpeas
+   * for Silverpeas. By default SILVERPEAS_HOME/configuration/jboss/modules.
    */
-  final File jbossModulesDir
+  final Property<File> jbossModulesDir
 
   /**
    * The Silverpeas settings as defined in the <code>config.properties</code> file.
@@ -84,11 +78,19 @@ class SilverpeasConfigurationProperties {
 
   @Inject
   SilverpeasConfigurationProperties(Project project, File silverpeasHome) {
-    configurationHome = project.file("${silverpeasHome.path}/configuration")
-    jbossConfigurationDir = project.file("${silverpeasHome.path}/configuration/jboss")
-    silverpeasConfigurationDir = project.file("${silverpeasHome.path}/configuration/silverpeas")
-    jbossModulesDir = project.file("${jbossConfigurationDir.path}/modules")
-    context = new Context(configurationHome, settings)
+    configurationHome = project.objects.property(File)
+    configurationHome.set(new File(silverpeasHome, 'configuration'))
+
+    jbossConfigurationDir = project.objects.property(File)
+    jbossConfigurationDir.set(new File(configurationHome.get(), 'jboss'))
+
+    silverpeasConfigurationDir = project.objects.property(File)
+    silverpeasConfigurationDir.set(new File(configurationHome.get(), 'silverpeas'))
+
+    jbossModulesDir = project.objects.property(File)
+    jbossModulesDir.set(new File(jbossConfigurationDir.get(), 'modules'))
+
+    context = new Context(configurationHome.get(), settings)
   }
 
   void setSettings(final Map configProperties) {

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasInstallationProperties.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasInstallationProperties.groovy
@@ -1,0 +1,65 @@
+package org.silverpeas.setup
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+
+import javax.inject.Inject
+/**
+ * Properties for the installation and deployment of Silverpeas in a JBoss server.
+ * @author mmoquillon
+ */
+class SilverpeasInstallationProperties {
+
+  /**
+   * The distribution directory. It is the directory that contains all the content of the
+   * constructed Silverpeas collaborative application. Defaulted into the build directory. Set a
+   * different location is pertinent only for development mode as in this mode the distribution
+   * directory is deployed as such in the JBoss/Wildfly application server.
+   * environment variable.
+   */
+  final Property<File> distDir
+
+  /**
+   * Directory that have to contain all the application or resource archives to deploy into
+   * JBoss/Wildfly. Defaulted in the SILVERPEAS_HOME/deployments directory.
+   */
+  final Property<File> deploymentDir
+
+  /**
+   * Directory that have to contain all the drivers required by Silverpeas and the Silverpeas Setup
+   * plugin to access the data source of Silverpeas.
+   */
+  final Property<File> dsDriversDir
+
+  /**
+   * Is in development mode? (In this case, some peculiar configuration are applied to support the
+   * dev mode in the application server.) This is a property and hence can be set by the user input
+   * from the build script.
+   */
+  final Property<Boolean> developmentMode
+
+  /**
+   * Collections of software bundles required to construct the Silverpeas application.These bundles
+   * will be downloaded from our software repository server (provided by our Nexus service) and then
+   * unpacked to a given directory in order to generate the final application.
+   */
+  final SoftwareBundles bundles
+
+  @Inject
+  SilverpeasInstallationProperties(Project project, File silverpeasHome) {
+    distDir = project.objects.property(File)
+    distDir.set(new File(project.buildDir, "dist"))
+    deploymentDir = project.objects.property(File)
+    deploymentDir.set(new File(silverpeasHome, 'deployments'))
+    dsDriversDir = project.objects.property(File)
+    dsDriversDir.set(new File(project.buildDir, "drivers"))
+    developmentMode = project.objects.property(Boolean)
+    developmentMode.set(false)
+    bundles = project.objects.newInstance(SoftwareBundles, project)
+  }
+
+  void bundles(Action<? extends SoftwareBundles> action) {
+    action.execute(bundles)
+  }
+}

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasMigrationProperties.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasMigrationProperties.groovy
@@ -1,0 +1,39 @@
+package org.silverpeas.setup
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+
+import javax.inject.Inject
+
+/**
+ * Properties for the migration of the data source used by Silverpeas when installing it or
+ * upgrading it to a new version.
+ * @author mmoquillon
+ */
+class SilverpeasMigrationProperties {
+
+  /**
+   * The directory in which are all located both the data source migration descriptors
+   * and the scripts to create or to update the schema of the database to be used by Silverpeas.
+   * It is defaulted to SILVERPEAS_HOME/migrations.
+   * It is expected to contain two kinds of subdirectories:
+   * <ul>
+   *   <li><em><code>modules</code></em> in which are provided the XML descriptor of each migration
+   *   module. These descriptors refers the scripts to use to create or to update the
+   *   database schema for a given Silverpeas module;</li>
+   *   <li><em><code>db</code></em> in which are located per database type and per module the
+   *   different SQL scripts to create or to upgrade the schema of the database;</li>
+   *   <li><em><code>scripts</code></em> in which are located per module the different programming
+   *   scripts (currently, only Groovy is supported) to perform complex tasks on the database or
+   *   any other data sources used by Silverpeas (like the JCR for example).
+   *   </li>
+   * </ul>
+   */
+  final Property<File> homeDir
+
+  @Inject
+  SilverpeasMigrationProperties(Project project, File silverpeasHome) {
+    this.homeDir = project.objects.property(File)
+    this.homeDir.set(new File(silverpeasHome, 'migrations'))
+  }
+}

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasSetupExtension.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasSetupExtension.groovy
@@ -99,7 +99,10 @@ class SilverpeasSetupExtension {
 
   /**
    * Constructs a new silverpeas configuration extension. It checks the environment variables
-   * SILVERPEAS_HOME and JBOSS_HOME are correctly set.
+   * SILVERPEAS_HOME and JBOSS_HOME are correctly set and it sets in the settings variable
+   * (that is shared by all the steps implied within a configuration of Silverpeas) the peculiar
+   * <code>context</code> attribute that is a dictionary of all the context properties the steps
+   * in a configuration process can set for their usage.
    */
   SilverpeasSetupExtension(Project project) {
     String silverpeasHomePath = SystemWrapper.getenv('SILVERPEAS_HOME')
@@ -121,8 +124,8 @@ class SilverpeasSetupExtension {
     migration = project.objects.newInstance(SilverpeasMigrationProperties, project, silverpeasHome)
     logging = project.objects.newInstance(SilverpeasLoggingProperties)
     timeout = project.objects.property(Long)
-    timeout.set(300000l)
-    JBossServer.DEFAULT_TIMEOUT = timeout.get()
+    timeout.set(JBossServer.DEFAULT_TIMEOUT)
+    settings.context = config.context.properties()
   }
 
   void setSettings(final Map configProperties) {

--- a/src/main/groovy/org/silverpeas/setup/SilverpeasSetupPlugin.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SilverpeasSetupPlugin.groovy
@@ -175,7 +175,7 @@ class SilverpeasSetupPlugin implements Plugin<Project> {
       build.outputs.upToDateWhen {
         boolean ok = extension.installation.distDir.get().exists() &&
             Files.exists(Paths.get(extension.installation.distDir.get().path, 'WEB-INF', 'web.xml'))
-        if (!extension.installation.developmentMode) {
+        if (!extension.installation.developmentMode.get()) {
           ok = ok && Files.exists(
               Paths.get(project.buildDir.path, SilverpeasConstructionTask.SILVERPEAS_WAR))
         }

--- a/src/main/groovy/org/silverpeas/setup/SoftwareBundles.groovy
+++ b/src/main/groovy/org/silverpeas/setup/SoftwareBundles.groovy
@@ -1,0 +1,44 @@
+package org.silverpeas.setup
+
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+
+import javax.inject.Inject
+
+/**
+ * Collections of software bundles required to construct the Silverpeas application.These bundles
+ * will be downloaded from our software repository server (provided by our Nexus service) and then
+ * unpacked to a given directory in order to generate the final application.
+ * @author mmoquillon
+ */
+class SoftwareBundles {
+
+  /**
+   * All the software bundles that made Silverpeas. Those bundles are usually downloaded from our
+   * own Software Repository by the Silverpeas installer. They are required to assemble and build
+   * the final Silverpeas Web Application. The Jar libraries other than the supported JDBC drivers
+   * aren't taken in charge.
+   */
+  final ConfigurableFileCollection silverpeas
+
+  /**
+   * Any tiers bundles to add into the Silverpeas Application being built. The tiers bundles are
+   * processed differently by the plugin: only the JAR libraries are taken in charge.
+   */
+  final ConfigurableFileCollection tiers
+
+  @Inject
+  SoftwareBundles(Project project) {
+    silverpeas = project.files()
+    tiers = project.files()
+  }
+
+  void setSilverpeas(FileCollection bundles) {
+    this.silverpeas.setFrom(bundles)
+  }
+
+  void setTiers(FileCollection bundles) {
+    this.tiers.setFrom(bundles)
+  }
+}

--- a/src/main/groovy/org/silverpeas/setup/TaskEventLogging.groovy
+++ b/src/main/groovy/org/silverpeas/setup/TaskEventLogging.groovy
@@ -68,15 +68,16 @@ class TaskEventLogging extends BuildAdapter implements TaskExecutionListener {
         buildStarted = true
         SilverpeasSetupExtension silverSetup =
             (SilverpeasSetupExtension) task.project.extensions.getByName(SilverpeasSetupPlugin.EXTENSION)
+        String javaHome = System.getenv('JAVA_HOME')
         FileLogger.getLogger(DEFAULT_LOG_NAMESPACE).formatInfo('%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n',
             "SILVERPEAS SETUP: ${task.project.version}",
             "SILVERPEAS HOME:  ${silverSetup.silverpeasHome.path}",
             "JBOSS HOME:       ${silverSetup.jbossHome.path}",
             "JCR HOME:         ${silverSetup.settings.JCR_HOME.asPath().toString()}",
-            "JAVA HOME:        ${System.getenv('JAVA_HOME')}",
+            "JAVA HOME:        ${javaHome != null ? javaHome : 'not set'}",
             "DATABASE:         ${silverSetup.settings.DB_SERVERTYPE.toLowerCase()}",
             "OPERATING SYSTEM: ${System.getProperty('os.name')}",
-            "PRODUCTION MODE:  ${!silverSetup.installation.developmentMode}")
+            "PRODUCTION MODE:  ${!silverSetup.installation.developmentMode.get()}")
       }
       FileLogger log = FileLogger.getLogger(task.name)
       String taskTitle = unformat(task.name)

--- a/src/main/groovy/org/silverpeas/setup/TaskEventLogging.groovy
+++ b/src/main/groovy/org/silverpeas/setup/TaskEventLogging.groovy
@@ -72,11 +72,11 @@ class TaskEventLogging extends BuildAdapter implements TaskExecutionListener {
             "SILVERPEAS SETUP: ${task.project.version}",
             "SILVERPEAS HOME:  ${silverSetup.silverpeasHome.path}",
             "JBOSS HOME:       ${silverSetup.jbossHome.path}",
-            "JCR HOME:         ${silverSetup.config.settings.JCR_HOME.asPath().toString()}",
+            "JCR HOME:         ${silverSetup.settings.JCR_HOME.asPath().toString()}",
             "JAVA HOME:        ${System.getenv('JAVA_HOME')}",
-            "DATABASE:         ${silverSetup.config.settings.DB_SERVERTYPE.toLowerCase()}",
+            "DATABASE:         ${silverSetup.settings.DB_SERVERTYPE.toLowerCase()}",
             "OPERATING SYSTEM: ${System.getProperty('os.name')}",
-            "PRODUCTION MODE:  ${!silverSetup.developmentMode}")
+            "PRODUCTION MODE:  ${!silverSetup.installation.developmentMode}")
       }
       FileLogger log = FileLogger.getLogger(task.name)
       String taskTitle = unformat(task.name)

--- a/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
@@ -81,13 +81,14 @@ class JBossServer {
   }
 
   private void assertCommandSucceeds(command) throws AssertionError, InvalidObjectException {
-    String message = command.in.text
-    if (command.exitValue() != 0 || message.contains('"outcome" => "failed"')) {
-      String error = command.err.text
-      if (!error) {
-        throw new InvalidObjectException(message)
+    String result = command.in.text
+    if (command.exitValue() != 0 || result.contains('"outcome" => "failed"')) {
+      boolean rollBacked = result.contains('"rolled-back" => true')
+      String msg = "Execution Output: \n${result}"
+      if (!rollBacked) {
+        throw new InvalidObjectException(msg)
       }
-      throw new AssertionError(error)
+      throw new AssertionError(msg)
     }
   }
 
@@ -503,6 +504,7 @@ class JBossServer {
       logger.warn "Invalid resource. ${e.message}"
     } catch (AssertionError | Exception e) {
       logger.info "${commandsFile.name} processing: [FAILURE]"
+      logger.error e.message
       throw e
     }
   }

--- a/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
@@ -43,7 +43,7 @@ import java.util.regex.Matcher
  */
 class JBossServer {
 
-  static long DEFAULT_TIMEOUT = 120000
+  static long DEFAULT_TIMEOUT = 300000l
 
   private String cli
 

--- a/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/JBossServer.groovy
@@ -43,6 +43,8 @@ import java.util.regex.Matcher
  */
 class JBossServer {
 
+  static long DEFAULT_TIMEOUT = 120000
+
   private String cli
 
   private String starter
@@ -51,7 +53,7 @@ class JBossServer {
 
   private File redirection = null
 
-  private long timeout = 120000
+  private long timeout = DEFAULT_TIMEOUT
 
   private FileLogger logger = FileLogger.getLogger(getClass().getSimpleName(), System.out)
 
@@ -165,7 +167,7 @@ class JBossServer {
    * @return itself.
    */
   JBossServer withStartingTimeout(long timeout) {
-    if (this.timeout!= null && this.timeout > 0) {
+    if (this.timeout != null && this.timeout > 0) {
       this.timeout = timeout
     }
     return this

--- a/src/main/groovy/org/silverpeas/setup/api/SilverpeasSetupService.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/SilverpeasSetupService.groovy
@@ -45,7 +45,8 @@ class SilverpeasSetupService {
   final Map settings
 
   /**
-   * Create a new Silverpeas setup service with the specified Silverpeas settings.
+   * Create a new Silverpeas setup service with the specified Silverpeas settings and configuration
+   * context.
    * @param settings a Map instance with all the global settings for the installation and
    * configuration of Silverpeas
    */

--- a/src/main/groovy/org/silverpeas/setup/api/SilverpeasSetupTask.groovy
+++ b/src/main/groovy/org/silverpeas/setup/api/SilverpeasSetupTask.groovy
@@ -1,0 +1,18 @@
+package org.silverpeas.setup.api
+
+import org.gradle.api.DefaultTask
+
+/**
+ * Common definition of a task in the Silverpeas Setup plugin.
+ * @author mmoquillon
+ */
+abstract class SilverpeasSetupTask extends DefaultTask {
+
+  /**
+   * The settings is a dictionary of all configuration properties initially loaded from the
+   * <code>config.properties</code> file and computed by the plugin. Any task can also set
+   * additional properties in order to share information with other tasks. Usually, the settings
+   * should be injected in the scripts that are executed by a task.
+   */
+  Map settings
+}

--- a/src/main/groovy/org/silverpeas/setup/configuration/ConfigurationScriptBuilder.groovy
+++ b/src/main/groovy/org/silverpeas/setup/configuration/ConfigurationScriptBuilder.groovy
@@ -75,7 +75,7 @@ class ConfigurationScriptBuilder {
     switch(type.toLowerCase()) {
       case 'cli':
         if (cliScript) {
-          cliScript.toFile() << new File(scriptPath).text
+          cliScript.toFile() << new File(scriptPath).text + '\n'
           script = cliScript
         } else {
           script = new JBossCliScript(scriptPath)

--- a/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
+++ b/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
@@ -146,6 +146,7 @@ class JBossConfigurationTask extends SilverpeasSetupTask {
             (driver.name.startsWith('ojdbc') && settings.DB_SERVERTYPE == 'ORACLE')) {
           settings.DB_DRIVER_NAME = driver.name
           try {
+            server.remove(settings.DB_DRIVER_NAME)
             server.add(Paths.get(driversDir.path, settings.DB_DRIVER_NAME).toString())
             server.deploy(settings.DB_DRIVER_NAME)
           } catch (Exception ex) {

--- a/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
+++ b/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
@@ -23,7 +23,7 @@
  */
 package org.silverpeas.setup.configuration
 
-import org.gradle.api.DefaultTask
+
 import org.gradle.api.Project
 import org.gradle.api.ProjectState
 import org.gradle.api.provider.Property
@@ -33,17 +33,17 @@ import org.silverpeas.setup.SilverpeasConfigurationProperties
 import org.silverpeas.setup.api.FileLogger
 import org.silverpeas.setup.api.JBossServer
 import org.silverpeas.setup.api.Script
+import org.silverpeas.setup.api.SilverpeasSetupTask
 
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.regex.Matcher
-
 /**
  * A Gradle task to configure a JBoss/Wildfly instance from some CLI scripts to be ready to run
  * Silverpeas.
  * @author mmoquillon
  */
-class JBossConfigurationTask extends DefaultTask {
+class JBossConfigurationTask extends SilverpeasSetupTask {
 
   File driversDir
   SilverpeasConfigurationProperties config
@@ -98,11 +98,11 @@ class JBossConfigurationTask extends DefaultTask {
     }).each { conf ->
       String jvmOpts; def regexp
       if (conf.name.endsWith('.bat')) {
-        jvmOpts = "set \"JAVA_OPTS=-Xmx${config.settings.JVM_RAM_MAX} ${config.settings.JVM_OPTS}"
+        jvmOpts = "set \"JAVA_OPTS=-Xmx${settings.JVM_RAM_MAX} ${settings.JVM_OPTS}"
         regexp = /\s*set\s+"JAVA_OPTS=-Xm.+/
       } else {
         jvmOpts =
-            "JAVA_OPTS=\"-Xmx${config.settings.JVM_RAM_MAX} -Djava.net.preferIPv4Stack=true ${config.settings.JVM_OPTS}"
+            "JAVA_OPTS=\"-Xmx${settings.JVM_RAM_MAX} -Djava.net.preferIPv4Stack=true ${settings.JVM_OPTS}"
         regexp = /\s*JAVA_OPTS="-Xm.+/
       }
       jvmOpts += '"'
@@ -127,29 +127,29 @@ class JBossConfigurationTask extends DefaultTask {
   private void installAdditionalModules() {
     log.info 'Additional modules installation'
     project.copy {
-      it.from config.jbossModulesDir.toPath()
+      it.from config.jbossModulesDir.get().toPath()
       it.into Paths.get(jboss.get().jbossHome, 'modules')
     }
   }
 
   private void setUpJDBCDriver() throws Exception {
-    log.info "Install database driver for ${config.settings.DB_SERVERTYPE}"
+    log.info "Install database driver for ${settings.DB_SERVERTYPE}"
     JBossServer server = jboss.get()
-    if (config.settings.DB_SERVERTYPE == 'H2') {
+    if (settings.DB_SERVERTYPE == 'H2') {
       // H2 is already available by default in JBoss/Wildfly
-      config.settings.DB_DRIVER_NAME = 'h2'
+      settings.DB_DRIVER_NAME = 'h2'
     } else {
       // install the required driver other than H2
       driversDir.listFiles().each { driver ->
-        if ((driver.name.startsWith('postgresql') && config.settings.DB_SERVERTYPE == 'POSTGRESQL') ||
-            (driver.name.startsWith('jtds') && config.settings.DB_SERVERTYPE == 'MSSQL') ||
-            (driver.name.startsWith('ojdbc') && config.settings.DB_SERVERTYPE == 'ORACLE')) {
-          config.settings.DB_DRIVER_NAME = driver.name
+        if ((driver.name.startsWith('postgresql') && settings.DB_SERVERTYPE == 'POSTGRESQL') ||
+            (driver.name.startsWith('jtds') && settings.DB_SERVERTYPE == 'MSSQL') ||
+            (driver.name.startsWith('ojdbc') && settings.DB_SERVERTYPE == 'ORACLE')) {
+          settings.DB_DRIVER_NAME = driver.name
           try {
-            server.add(Paths.get(driversDir.path, config.settings.DB_DRIVER_NAME).toString())
-            server.deploy(config.settings.DB_DRIVER_NAME)
+            server.add(Paths.get(driversDir.path, settings.DB_DRIVER_NAME).toString())
+            server.deploy(settings.DB_DRIVER_NAME)
           } catch (Exception ex) {
-            log.error("Error: cannot deploy ${config.settings.DB_DRIVER_NAME}", ex)
+            log.error("Error: cannot deploy ${settings.DB_DRIVER_NAME}", ex)
             throw ex
           }
         }
@@ -162,7 +162,7 @@ class JBossConfigurationTask extends DefaultTask {
         Files.createTempFile('jboss-configuration-', '.cli').toString())
     log.info "CLI configuration scripts will be merged into ${cliScript.toFile().name}"
     Set<Script> scripts = new HashSet<>()
-    config.jbossConfigurationDir.listFiles(new FileFilter() {
+    config.jbossConfigurationDir.get().listFiles(new FileFilter() {
       @Override
       boolean accept(final File child) {
         return child.isFile()
@@ -177,7 +177,7 @@ class JBossConfigurationTask extends DefaultTask {
       scripts.each { aScript ->
         aScript
             .useLogger(log)
-            .useSettings(config.settings)
+            .useSettings(settings)
             .run(jboss: jboss.get())
       }
     } catch(Exception ex) {

--- a/src/main/groovy/org/silverpeas/setup/configuration/SilverpeasConfigurationTask.groovy
+++ b/src/main/groovy/org/silverpeas/setup/configuration/SilverpeasConfigurationTask.groovy
@@ -23,21 +23,23 @@
  */
 package org.silverpeas.setup.configuration
 
-import org.gradle.api.DefaultTask
+
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskExecutionException
 import org.silverpeas.setup.SilverpeasConfigurationProperties
 import org.silverpeas.setup.api.FileLogger
 import org.silverpeas.setup.api.Script
+import org.silverpeas.setup.api.SilverpeasSetupTask
 
 import java.nio.file.Files
 import java.nio.file.Paths
+
 /**
  * This task aims to configure Silverpeas from the Silverpeas configuration file, from some XML
  * configuration rules and from Groovy scripts.
  * @author mmoquillon
  */
-class SilverpeasConfigurationTask extends DefaultTask {
+class SilverpeasConfigurationTask extends SilverpeasSetupTask {
 
   File silverpeasHome
   SilverpeasConfigurationProperties config
@@ -58,7 +60,7 @@ class SilverpeasConfigurationTask extends DefaultTask {
 
   @TaskAction
   void configureSilverpeas() {
-    config.silverpeasConfigurationDir.listFiles(new FileFilter() {
+    config.silverpeasConfigurationDir.get().listFiles(new FileFilter() {
       @Override
       boolean accept(final File child) {
         return child.isFile()
@@ -70,7 +72,7 @@ class SilverpeasConfigurationTask extends DefaultTask {
         Script script = ConfigurationScriptBuilder.fromScript(configurationFile.path).build()
         script
             .useLogger(log)
-            .useSettings(config.settings)
+            .useSettings(settings)
             .run()
       } catch (Exception ex) {
         log.error("Error while processing the configuration file ${configurationFile.path}", ex)

--- a/src/main/groovy/org/silverpeas/setup/construction/SilverpeasBuilder.groovy
+++ b/src/main/groovy/org/silverpeas/setup/construction/SilverpeasBuilder.groovy
@@ -27,6 +27,7 @@ import groovy.util.slurpersupport.GPathResult
 import groovy.xml.XmlUtil
 import org.gradle.api.Project
 import org.gradle.util.GFileUtils
+import org.silverpeas.setup.SoftwareBundles
 import org.silverpeas.setup.api.FileLogger
 import org.silverpeas.setup.api.ManagedBeanContainer
 import org.silverpeas.setup.api.SilverpeasSetupService
@@ -66,16 +67,16 @@ class SilverpeasBuilder {
    * Extracts all the specified software bundles into the specified destination directory. The
    * way the bundles are extracted follows the guide rules of the Silverpeas Portal Application
    * construction.
-   * @param silverpeasBundles a collection of the software bundles that makes Silverpeas.
-   * @param tiersBundles a collection of tiers bundles to add to Silverpeas. This bundles are
-   * processed differently than the Silverpeas ones.
+   * @param bundles collections of software bundles that makes Silverpeas.
    * @param destinationDir the destination directory into which the bundles will be extracted
    */
   void extractSoftwareBundles(
-      final Collection<File> silverpeasBundles,
-      final Collection<File> tiersBundles, final File destinationDir) {
+      final SoftwareBundles bundles,
+      final File destinationDir) {
     Objects.requireNonNull(silverpeasHome)
     Objects.requireNonNull(driversDir)
+    final Collection<File> silverpeasBundles = bundles.silverpeas.files
+    final Collection<File> tiersBundles = bundles.tiers.files
     def isAWar = { File f ->
       f.name.endsWith('.war') && !f.name.startsWith(CORE_WAR_BUNDLE_ID)
     }

--- a/src/main/resources/default_config.properties
+++ b/src/main/resources/default_config.properties
@@ -111,6 +111,14 @@ SERVER_EXECUTION_MODE=standalone
 # false. By default false.
 SERVER_SECURED=false
 
+# The timeout in seconds for the server to start Silverpeas. By default, the timeout of the
+# application deployment of the server (5mn in Wildfly). When Silverpeas is started by the server
+# (when it is deployed in the JEE jargon), it can take some times to initialize the resources that
+# depends on the amount of the data managed by Silverpeas and on the performance of both the
+# hardware and the filesystem. If you encounter a timeout error at Silverpeas starting, then
+# change the value here (for example, by setting it to 900 for 15mn)
+SERVER_STARTING_TIMEOUT = 300
+
 ####################################################################################################
 ## Properties of the database to use for Silverpeas.
 ####################################################################################################

--- a/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
@@ -52,7 +52,7 @@ class SilverpeasInstallationTaskTest extends GroovyTestCase {
   void testInstall() {
     SilverpeasInstallationTask task = project.tasks.findByPath(INSTALL.name)
 
-    File jackrabbit = new File(task.deploymentDir, 'jackrabbit-jca.rar')
+    File jackrabbit = new File(task.installation.deploymentDir.get(), 'jackrabbit-jca.rar')
     jackrabbit.createNewFile()
 
     def mock = new MockFor(JBossServer)


### PR DESCRIPTION
Restructure the different sections of settings of the plugin SilverSetup in
order to separate correctly what are for configuration of Silverpeas, what
are for installation and what are for the migration of the data source.

Add a new plugin setting property: timeout. It sets the timeout of the
waiting for JBoss to answer to the requests sent by the plugin. By
default it is set to 5mn (instead of 2mn) but it can be changed by
setting the property
silversetup {
  timeout = <the number of milliseconds to wait for>
}
in the SILVERPEAS_HOME/bin/build.gradle file.

Don't forget to merge then the PR https://github.com/Silverpeas/Silverpeas-Distribution/pull/5