### PR TITLE
Feature #12832 adding new configuration parameters

### DIFF
--- a/src/main/resources/default_config.properties
+++ b/src/main/resources/default_config.properties
@@ -123,6 +123,13 @@ SERVER_SECURED=false
 # change the value here (for example, by setting it to 900 for 15mn)
 SERVER_STARTING_TIMEOUT = 300
 
+# By default, the management console is only available on the machine of the running wildfly
+# at IP 127.0.0.1 and port 9990.
+# This variable allows the management console to be accessible from any server IP. This is useful
+# with a client server which does not provide WEB browser (which is generally the case).
+# By default, false (that means default wildfly behavior).
+SERVER_MANAGEMENT_ALL_IP = false
+
 ####################################################################################################
 ## Properties of the database to use for Silverpeas.
 ####################################################################################################
@@ -159,6 +166,7 @@ DB_MIN_POOL_SIZE=5
 DB_MAX_POOL_SIZE=120
 DB_IDLE_TIMEOUT=15
 DB_BLOCKING_TIMEOUT=30000
+DB_STATS_ENABLED=false
 
 ####################################################################################################
 ## Properties for the JCR used by Silverpeas to store document metadata.
@@ -178,6 +186,7 @@ JCR_MIN_POOL_SIZE=5
 JCR_MAX_POOL_SIZE=55
 JCR_IDLE_TIMEOUT=15
 JCR_BLOCKING_TIMEOUT=30000
+JCR_STATS_ENABLED=false
 
 ####################################################################################################
 ## Document Conversion Service properties.

--- a/src/test/resources/configuration/config.properties
+++ b/src/test/resources/configuration/config.properties
@@ -143,6 +143,7 @@ DB_NAME=test
 #DB_MAX_POOL_SIZE=55
 #DB_IDLE_TIMEOUT=15
 #DB_BLOCKING_TIMEOUT=30000
+#DB_STATS_ENABLED=false
 
 ####################################################################################################
 ## Properties for the JCR used by Silverpeas to store document metadata.
@@ -162,6 +163,7 @@ DB_NAME=test
 #JCR_MAX_POOL_SIZE=55
 #JCR_IDLE_TIMEOUT=15
 #JCR_BLOCKING_TIMEOUT=30000
+#JCR_STATS_ENABLED=false
 
 ####################################################################################################
 ## Document Conversion Service properties.


### PR DESCRIPTION
Adding parameter JCR_STATS_ENABLED and DB_STATS_ENABLED in order to enable the statistics on Silverpeas's used data sources. When statistics enabled on a data source, its pool state can be analyzed in real time from management console.

Adding boolean SERVER_MANAGEMENT_ALL_IP parameter which allows to enable the management services access from server IP and not only localhost. This is useful with Silverpeas's servers not providing WEB browsers.

Linked to PR https://github.com/Silverpeas/Silverpeas-Distribution/pull/9