### PR TITLE
Feature #12861: playing cli scripts as a sorted way in order to allow production environment managers to get an execution priority between all cli scripts.

### DIFF
--- a/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
+++ b/src/main/groovy/org/silverpeas/setup/configuration/JBossConfigurationTask.groovy
@@ -164,17 +164,20 @@ class JBossConfigurationTask extends SilverpeasSetupTask {
         Files.createTempFile('jboss-configuration-', '.cli').toString())
     log.info "CLI configuration scripts will be merged into ${cliScript.toFile().name}"
     Set<Script> scripts = new HashSet<>()
-    config.jbossConfigurationDir.get().listFiles(new FileFilter() {
-      @Override
-      boolean accept(final File child) {
-        return child.isFile()
-      }
-    }).each { File confFile ->
-      log.info "Load configuration file ${confFile.name}"
-      scripts.add(ConfigurationScriptBuilder.fromScript(confFile.path)
-          .mergeOnlyIfCLIInto(cliScript)
-          .build())
-    }
+    config.jbossConfigurationDir.get()
+        .listFiles(new FileFilter() {
+          @Override
+          boolean accept(final File child) {
+            return child.isFile()
+          }
+        })
+        .sort { it.name.toLowerCase() }
+        .each { File confFile ->
+          log.info "Load configuration file ${confFile.name}"
+          scripts.add(ConfigurationScriptBuilder.fromScript(confFile.path)
+              .mergeOnlyIfCLIInto(cliScript)
+              .build())
+        }
     try {
       scripts.each { aScript ->
         aScript


### PR DESCRIPTION
It has been chosen here to apply an alphabetical sort without taking care about the file name case. The idea is to get same sort between the different OS environement about this specific phase of CLI script execution.