### PR TITLE
Fixed test "testInstall" enabling to run independently

### DIFF
--- a/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
+++ b/src/test/groovy/org/silverpeas/setup/installation/SilverpeasInstallationTaskTest.groovy
@@ -50,7 +50,12 @@ class SilverpeasInstallationTaskTest {
   void testInstall() {
     SilverpeasInstallationTask task = project.tasks.findByPath(INSTALL.name)
 
-    File jackrabbit = new File(task.installation.deploymentDir.get(), 'jackrabbit-jca.rar')
+    File deploymentDir = task.installation.deploymentDir.get()
+    if (!deploymentDir.exists()) {
+      deploymentDir.mkdirs()
+    }
+
+    File jackrabbit = new File(deploymentDir, 'jackrabbit-jca.rar')
     jackrabbit.createNewFile()
 
     def mock = new MockFor(JBossServer)


### PR DESCRIPTION
This PR aims to fix the test `org.silverpeas.setup.installation.SilverpeasInstallationTaskTest.testInstall`

Currently, this test fails when run by itself. This occurs because the `testInstall` attempts to access a directory that is expected to have been previously generated. 
 
This pull request proposes a fix to make the test pass when run by itself by creating the directory instead.

Please let me know if you want to discuss further about the changes.
